### PR TITLE
Update URI's to reflect repo move

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,13 @@ These scripts can be used to assist in setup of a brand new Windows Server as a 
 ```powershell
 Set-ExecutionPolicy Bypass -Scope Process -Force
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::tls12
-$QuickStart = 'https://raw.githubusercontent.com/adilio/choco-quickstart-scripts/main/Start-C4BSetup.ps1'
-Invoke-Expression -Command ((New-Object System.Net.WebClient).DownloadString($QuickStart))
+Invoke-Expression -Command ((New-Object System.Net.WebClient).DownloadString('https://ch0.co/quickstart'))
 ```
+
+> :warning: **Warning**
+>
+> If your organization blocks the usage of short URI's, you can replace `https://ch0.co/quickstart` in the
+> command above with `https://raw.githubusercontent.com/chocolatey/choco-quickstart-scripts/main/Start-C4BSetup.ps1`
 
 ### Step 2: Nexus Setup
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,9 @@ These scripts can be used to assist in setup of a brand new Windows Server as a 
 ```powershell
 Set-ExecutionPolicy Bypass -Scope Process -Force
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::tls12
+$QuickStart = 'https://raw.githubusercontent.com/chocolatey/choco-quickstart-scripts/main/Start-C4BSetup.ps1'
 Invoke-Expression -Command ((New-Object System.Net.WebClient).DownloadString('https://ch0.co/quickstart'))
 ```
-
-> :warning: **Warning**
->
-> If your organization blocks the usage of short URI's, you can replace `https://ch0.co/quickstart` in the
-> command above with `https://raw.githubusercontent.com/chocolatey/choco-quickstart-scripts/main/Start-C4BSetup.ps1`
 
 ### Step 2: Nexus Setup
 

--- a/Start-C4BNexusSteup.ps1
+++ b/Start-C4BNexusSteup.ps1
@@ -939,7 +939,7 @@ function New-NexusRawComponent {
 }
 
 # Install base nexus-repository package
-choco install nexus-repository -y
+choco install nexus-repository -y --source="'https://chocolatey.org/api/v2/'"
 
 #Build Credential Object, Connect to Nexus
 $securePw = (Get-Content 'C:\programdata\sonatype-work\nexus3\admin.password') | ConvertTo-SecureString -AsPlainText -Force
@@ -981,7 +981,7 @@ choco apikey -s 'ChocolateyInternal' -k $NugetApiKey
 # Install a non-IE browser for browsing the Nexus web portal.
 # Edge sometimes fails install due to latest Windows Updates not being installed.
 # In that scenario, Google Chrome is installed instead.
-$null = choco install microsoft-edge -y
+$null = choco install microsoft-edge -y --source="'https://chocolatey.org/api/v2/'"
 if ($LASTEXITCODE -eq 0) {
     $RegArgs = @{
         Path = 'HKLM:\SOFTWARE\Microsoft\Edge\'
@@ -995,7 +995,7 @@ if ($LASTEXITCODE -eq 0) {
 else {
     Write-Warning "Microsoft Edge install was not succesful."
     Write-Host "Installing Google Chrome as an alternative."
-    choco install googlechrome -y
+    choco install googlechrome -y --source="'https://chocolatey.org/api/v2/'"
 }
 
 # Add Nexus port 8081 access via firewall

--- a/Start-C4BNexusSteup.ps1
+++ b/Start-C4BNexusSteup.ps1
@@ -981,7 +981,7 @@ choco apikey -s 'ChocolateyInternal' -k $NugetApiKey
 # Install a non-IE browser for browsing the Nexus web portal.
 # Edge sometimes fails install due to latest Windows Updates not being installed.
 # In that scenario, Google Chrome is installed instead.
-$null = choco install microsoft-edge -y --source="'https://chocolatey.org/api/v2/'"
+$null = choco install microsoft-edge -y --source="'https://community.chocolatey.org/api/v2/'"
 if ($LASTEXITCODE -eq 0) {
     $RegArgs = @{
         Path = 'HKLM:\SOFTWARE\Microsoft\Edge\'
@@ -995,7 +995,7 @@ if ($LASTEXITCODE -eq 0) {
 else {
     Write-Warning "Microsoft Edge install was not succesful."
     Write-Host "Installing Google Chrome as an alternative."
-    choco install googlechrome -y --source="'https://chocolatey.org/api/v2/'"
+    choco install googlechrome -y --source="'https://community.chocolatey.org/api/v2/'"
 }
 
 # Add Nexus port 8081 access via firewall

--- a/Start-C4BSetup.ps1
+++ b/Start-C4BSetup.ps1
@@ -92,7 +92,7 @@ $TempDir = "$ChocoPath\temp"
 	}
 
 # Download and extract C4B setup files from repo
-$QsRepo = "https://github.com/adilio/choco-quickstart-scripts/archive/main.zip"
+$QsRepo = "https://github.com/chocolatey/choco-quickstart-scripts/archive/main.zip"
 Invoke-WebRequest -Uri $QsRepo -UseBasicParsing -OutFile "$TempDir\main.zip"
 Expand-Archive "$TempDir\main.zip" $TempDir
 Copy-Item "$TempDir\choco-quickstart-scripts-main\*" $FilesDir -Recurse

--- a/Start-C4BSetup.ps1
+++ b/Start-C4BSetup.ps1
@@ -112,19 +112,19 @@ $PkgsDir = "$env:SystemDrive\choco-setup\packages"
 # Download Chocolatey community related items, no internalization necessary
 @('chocolatey','chocolateygui') |
     Foreach-Object {
-        choco download $_ --no-progress --force --source="'https://chocolatey.org/api/v2/'" --output-directory $PkgsDir
+        choco download $_ --no-progress --force --source="'https://community.chocolatey.org/api/v2/'" --output-directory $PkgsDir
     }
 
 # This is for SQL Server Express and Community related items
 @('sql-server-express','sql-server-management-studio','dotnet4.6.1','dotnet4.5.2') |
     Foreach-Object {
-	    choco download $_ --no-progress --force --internalize --internalize-all-urls --append-use-original-location --source="'https://chocolatey.org/api/v2/'" --output-directory $PkgsDir
+	    choco download $_ --no-progress --force --internalize --internalize-all-urls --append-use-original-location --source="'https://community.chocolatey.org/api/v2/'" --output-directory $PkgsDir
     }
 
 # We must use the 2.2.7 versions of these packages, so we need to download/internalize these specific items
 @('aspnetcore-runtimepackagestore','dotnetcore-windowshosting') |
     Foreach-Object {
-	    choco download $_ --version 2.2.7 --no-progress --force --internalize --internalize-all-urls --append-use-original-location --source="'https://chocolatey.org/api/v2/'" --output-directory $PkgsDir
+	    choco download $_ --version 2.2.7 --no-progress --force --internalize --internalize-all-urls --append-use-original-location --source="'https://community.chocolatey.org/api/v2/'" --output-directory $PkgsDir
     }
 
 # Download Licensed Packages


### PR DESCRIPTION
This is a small update to reflect the new URI's since the repo has been moved to the `chocolatey` organization.

Closes #14 .