### PR TITLE
Fix Edge regkey failing on 2016

### DIFF
--- a/Start-C4BNexusSteup.ps1
+++ b/Start-C4BNexusSteup.ps1
@@ -997,7 +997,7 @@ if ($LASTEXITCODE -eq 0) {
 else {
     Write-Warning "Microsoft Edge install was not succesful."
     Write-Host "Installing Google Chrome as an alternative."
-    choco install googlechrome -y
+    choco install googlechrome -y --source="'https://community.chocolatey.org/api/v2/'"
 }
 
 # Add Nexus port 8081 access via firewall

--- a/Start-C4BNexusSteup.ps1
+++ b/Start-C4BNexusSteup.ps1
@@ -983,19 +983,21 @@ choco apikey -s 'ChocolateyInternal' -k $NugetApiKey
 # In that scenario, Google Chrome is installed instead.
 $null = choco install microsoft-edge -y --source="'https://community.chocolatey.org/api/v2/'"
 if ($LASTEXITCODE -eq 0) {
-    $RegArgs = @{
+    if (Test-Path 'HKLM:\SOFTWARE\Microsoft\Edge') {
+        $RegArgs = @{
         Path = 'HKLM:\SOFTWARE\Microsoft\Edge\'
         Name = 'HideFirstRunExperience'
         Type = 'Dword'
         Value = 1
         Force = $true
         }
-    Set-ItemProperty @RegArgs
+        Set-ItemProperty @RegArgs
+    }
 }
 else {
     Write-Warning "Microsoft Edge install was not succesful."
     Write-Host "Installing Google Chrome as an alternative."
-    choco install googlechrome -y --source="'https://community.chocolatey.org/api/v2/'"
+    choco install googlechrome -y
 }
 
 # Add Nexus port 8081 access via firewall


### PR DESCRIPTION
Closes #21 .

Added logic into `if` loop to check and see if the parent registry key exists, and only create the value if it does:

```powershell
$null = choco install microsoft-edge -y --source="'https://community.chocolatey.org/api/v2/'"
if ($LASTEXITCODE -eq 0) {
    if (Test-Path 'HKLM:\SOFTWARE\Microsoft\Edge') {
        $RegArgs = @{
        Path = 'HKLM:\SOFTWARE\Microsoft\Edge\'
        Name = 'HideFirstRunExperience'
        Type = 'Dword'
        Value = 1
        Force = $true
        }
        Set-ItemProperty @RegArgs
    }
}
else {
    Write-Warning "Microsoft Edge install was not succesful."
    Write-Host "Installing Google Chrome as an alternative."
    choco install googlechrome -y
}
```