### PR TITLE
Fixed DateTime format for transcript

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ These scripts can be used to assist in setup of a brand new Windows Server as a 
 Set-ExecutionPolicy Bypass -Scope Process -Force
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::tls12
 $QuickStart = 'https://raw.githubusercontent.com/chocolatey/choco-quickstart-scripts/main/Start-C4BSetup.ps1'
-Invoke-Expression -Command ((New-Object System.Net.WebClient).DownloadString('https://ch0.co/quickstart'))
+Invoke-Expression -Command ((New-Object System.Net.WebClient).DownloadString($QuickStart))
 ```
 
 ### Step 2: Nexus Setup

--- a/Start-C4BNexusSteup.ps1
+++ b/Start-C4BNexusSteup.ps1
@@ -23,7 +23,7 @@ param(
 
 $DefaultEap = $ErrorActionPreference
 $ErrorActionPreference = 'Stop'
-Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Start-C4bNexusSetup-$(Get-Date -Format 'yyyyMMdd-hhmmss').txt"
+Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Start-C4bNexusSetup-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
 
 function Wait-Nexus {
     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::tls12

--- a/Start-C4BSetup.ps1
+++ b/Start-C4BSetup.ps1
@@ -23,7 +23,7 @@ param(
 
 $DefaultEap = $ErrorActionPreference
 $ErrorActionPreference = 'Stop'
-Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Start-C4bSetup-$(Get-Date -Format 'yyyyMMdd-hhmmss').txt"
+Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Start-C4bSetup-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
 
 function Install-ChocoLicensed {
 

--- a/Start-C4bCcmSetup.ps1
+++ b/Start-C4bCcmSetup.ps1
@@ -19,7 +19,7 @@ param(
 
 $DefaultEap = $ErrorActionPreference
 $ErrorActionPreference = 'Stop'
-Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Start-C4bCcmSetup-$(Get-Date -Format 'yyyyMMdd-hhmmss').txt"
+Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Start-C4bCcmSetup-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
 
 # DB Setup
 $PkgSrc = "$env:SystemDrive\choco-setup\packages"

--- a/Start-C4bJenkinsSetup.ps1
+++ b/Start-C4bJenkinsSetup.ps1
@@ -22,7 +22,7 @@ param(
 
 $DefaultEap = $ErrorActionPreference
 $ErrorActionPreference = 'Stop'
-Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Start-C4bJenkinsSetup-$(Get-Date -Format 'yyyyMMdd-hhmmss').txt"
+Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Start-C4bJenkinsSetup-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
 
 # Install Jenkins
 choco install jenkins -y --source $Source --no-progress --version 2.222.4


### PR DESCRIPTION
Closes #23 .

This fixes the format of the timestamp in the transcripts for each of the setup scripts.