### PR TITLE
Add cert import script and site

### DIFF
--- a/Set-SSLSecurity.ps1
+++ b/Set-SSLSecurity.ps1
@@ -230,7 +230,11 @@ process {
     Start-Service chocolatey-central-management
     # Hand back the created/found certificate to the caller.
     $Certificate
+
+    # Create the site hosting the certificate import script on port 80
+    .\scripts\New-IISCertificateHost.ps1
 }
+
 
 end {
     $Message = 'The CCM, Nexus & Jenkins sites will open in your browser in 10 seconds. Press any key to skip this.'

--- a/scripts/Import-ChocoServerCertificate.ps1
+++ b/scripts/Import-ChocoServerCertificate.ps1
@@ -1,0 +1,79 @@
+<#
+.SYNOPSIS
+Connects to the QDE server and adds its SSL certificate to the local certificate
+store.
+#>
+[CmdletBinding()]
+param(
+    # The hostname of the QDE server to retrieve the SSL certificate from.
+    [Parameter()]
+    [Alias('NexusServer', 'NexusUrl')]
+    [string]
+    $ComputerName = '{{hostname}}'
+)
+
+add-type -TypeDefinition @"
+using System;
+using System.Net;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+public static class Dummy {
+    public static bool ReturnTrue(object sender,
+        X509Certificate certificate,
+        X509Chain chain,
+        SslPolicyErrors sslPolicyErrors) { return true; }
+
+    public static RemoteCertificateValidationCallback GetDelegate() {
+        return new RemoteCertificateValidationCallback(Dummy.ReturnTrue);
+    }
+}
+"@
+
+$callback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback = [dummy]::GetDelegate()
+
+#Do it Matthias's way
+function Get-RemoteCertificate {
+    param(
+        [Alias('CN')]
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string]$ComputerName,
+
+        [Parameter(Position = 1)]
+        [UInt16]$Port = 8443
+    )
+
+    $tcpClient = New-Object System.Net.Sockets.TcpClient($ComputerName, $Port)
+    try {
+        $tlsClient = New-Object System.Net.Security.SslStream($tcpClient.GetStream(),'false',$callback)
+        $tlsClient.AuthenticateAsClient($ComputerName)
+
+        return $tlsClient.RemoteCertificate -as [System.Security.Cryptography.X509Certificates.X509Certificate2]
+    }
+    finally {
+        if ($tlsClient -is [IDisposable]) {
+            $tlsClient.Dispose()
+        }
+
+        $tcpClient.Dispose()
+    }
+}
+
+#Create request to CCM Service URL to get Certificate
+Write-Output "Connecting to '$ComputerName' to get certificate information"
+$certificateToAdd = Get-RemoteCertificate -ComputerName $ComputerName
+
+#Create CertStore object where the certificate needs "put"
+Write-Host "Adding Cert to LocalMachine\TrustedPeople Store"
+$Store = [System.Security.Cryptography.X509Certificates.StoreName]::TrustedPeople
+$Location = [System.Security.Cryptography.X509Certificates.StoreLocation]::LocalMachine
+$certStore = New-Object System.Security.Cryptography.X509Certificates.X509Store($Store, $Location)
+
+try {
+    $certStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+    $certStore.Add($certificateToAdd)
+}
+finally {
+    $certStore.Close()
+    Remove-Variable certstore
+}

--- a/scripts/New-IISCertificateHost.ps1
+++ b/scripts/New-IISCertificateHost.ps1
@@ -1,0 +1,71 @@
+<#
+.SYNOPSIS
+Creates the `ChocolateyInstall` IIS fileshare site.
+
+.DESCRIPTION
+Creates a new IIS website named `ChocolateyInstall` which hosts the
+Import-ChocoServerCertificate.ps1 for clients to retrieve and run during their
+setup.
+
+If you have a need to re-create this for any reason, ensure the existing
+`ChocolateyInstall` IIS site has been disabled and removed.
+#>
+[CmdletBinding()]
+param(
+    # The path to a local directory which will be used to host the
+    # Import-ChocoServerCertificate.ps1 file over IIS for clients to utilize.
+    [Parameter()]
+    [Alias('LocalDir')]
+    [string]
+    $Path = 'C:\tools\ChocolateyInstall'
+)
+
+Import-Module WebAdministration
+
+$hostName = [System.Net.Dns]::GetHostName()
+$domainName = [System.Net.NetworkInformation.IPGlobalProperties]::GetIPGlobalProperties().DomainName
+
+if (-not $hostName.endswith($domainName)) {
+    $hostName += "." + $domainName
+}
+
+if (-not (Test-Path $Path)) {
+    $null = New-Item -Path $Path -ItemType Directory -Force
+}
+
+$ImportScript = Join-Path $Path "Import-ChocoServerCertificate.ps1"
+if (-not (Test-Path $ImportScript)) {
+    Copy-Item -Path "$PSScriptRoot/Import-ChocoServerCertificate.ps1" -Destination $Path
+}
+(Get-Content -Path $ImportScript) -replace "{{hostname}}", $HostName | Set-Content -Path $ImportScript
+
+
+$siteName = 'C4bSslCertificateImport'
+if (-not (Get-Website -Name $siteName)) {
+    Write-Host "Creating Website: $siteName" -ForegroundColor Green
+    $null = New-Website -Name $siteName -Port 80 -PhysicalPath $Path -Force
+    Add-WebConfigurationProperty -PSPath IIS: -Filter system.webServer/staticContent -Name "." -Value @{ fileExtension = '.ps1'; mimeType = 'text/plain' }
+} else {
+    Write-Host "Website for hosting certificate import already created" -ForegroundColor Green
+}
+
+if ((Get-Website -Name 'Default Web Site')) {
+    Get-Website -Name 'Default Web Site' | Remove-Website
+} else {
+    Write-Host "Default website already removed" -ForegroundColor Green
+}
+
+Write-Host "Restarting IIS to refresh bindings" -ForegroundColor Green
+$null = iisreset
+
+if ((Get-Website -Name $siteName).State -ne 'Started') {
+    Start-Website -Name $siteName
+}
+
+if ((Get-Website -Name 'Default Web Site')) {
+    Get-Website -Name 'Default Web Site' | Remove-Website
+} else {
+    Write-Host "Default website already removed" -ForegroundColor Green
+}
+
+Write-Host "IIS website started on port 80 hosting Import-ChocoServerCertificate.ps1 from $Path"


### PR DESCRIPTION
Closes #35 .

Adds code to create the site hosting the certificate import script on port 80.

Clients will need this to import the self-signed cert, in order to trust the server.