### PR TITLE
Add readme file to desktop with creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Below is the planned revision of the QSG, which will eventually be posted in the
 ---
 Order: 30
 xref: c4b-quick-start-guide
-Title: Chocolatey for Business (C4B) Quick Start Guide
+Title: C4B Quick Start Guide
 Description: Get up and running quickly with Chocolatey for Business
 RedirectFrom: docs/chocolatey-for-business-quick-start-guide
 ---
@@ -181,8 +181,9 @@ Below are the minimum requirements for setting up your C4B server via this guide
     > <li>Updates Jenkins plugins</li>
     > <li>Configures pre-downloaded Jenkins scripts for Package Internalizer automation</li>
     > <li>Sets up pre-defined Jenkins jobs for the scripts above</li>
-    > <li>Auto-opens web portals for CCM, Nexus, and Jenkins in your web browser</li>
-    > <li>Outputs data to JSON to pass between scripts</li>
+    > <li>Writes README to Public Desktop with account information for C4B services</li>
+    > <li>Auto-opens README, CCM, Nexus, and Jenkins in your web browser</li>
+    > <li>Removes temporary JSON files used during provisioning</li>
     > </ul>
     > </details>
 
@@ -203,12 +204,12 @@ Below are the minimum requirements for setting up your C4B server via this guide
     > <ul class="list-style-type-disc">
     > <li>Installs Chocolatey client (`chocolatey`), using a script from your raw "`choco-install`" repository</li>
     > <li>Runs the `ClientSetup.ps1` script from your raw "`choco-install`" repository, which does the following:</li>
-    > <li>- Licenses Chocolatey by installing the license package (`chocolatey-license`) created during QDE setup</li>
-    > <li>- Installs the Chocolatey Licensed Extension (`chocolatey.extension`) without context menus</li>
-    > <li>- Configures ChocolateyInternal source</li>
-    > <li>- Disables access to the `chocolatey` public Chocolatey Community Repository (CCR)</li>
-    > <li>- Configures Self-Service mode and installs Chocolatey GUI (`chocolateygui`)</li>
-    > <li>- - Configures Central Management (CCM) check-in, and opts endpoints into CCM Deployments</li>
+    > <li>Licenses Chocolatey by installing the license package (`chocolatey-license`) created during QDE setup</li>
+    > <li>Installs the Chocolatey Licensed Extension (`chocolatey.extension`) without context menus</li>
+    > <li>Configures ChocolateyInternal source</li>
+    > <li>Disables access to the `chocolatey` public Chocolatey Community Repository (CCR)</li>
+    > <li>Configures Self-Service mode and installs Chocolatey GUI (`chocolateygui`)</li>
+    > <li>Configures Central Management (CCM) check-in, and opts endpoints into CCM Deployments</li>
     > </ul>
     > </details>
 

--- a/Start-C4bJenkinsSetup.ps1
+++ b/Start-C4bJenkinsSetup.ps1
@@ -24,6 +24,9 @@ $DefaultEap = $ErrorActionPreference
 $ErrorActionPreference = 'Stop'
 Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Start-C4bJenkinsSetup-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
 
+# Dot-source helper functions
+. .\scripts\Get-Helpers.ps1
+
 # Install Jenkins
 choco install jenkins -y --source $Source --no-progress --version 2.222.4
 choco pin add --name="'jenkins'" --version="'2.222.4'" --reason="'Next version is a breaking change; see online QDE documentation FAQ'"
@@ -162,6 +165,12 @@ Write-Host 'Login to Jenkins at: http://locahost:8080' -ForegroundColor Green
 Write-Host 'Initial default Jenkins admin user password:' -ForegroundColor Green
 Write-Host "$(Get-Content "${env:ProgramFiles(x86)}\Jenkins\secrets\initialAdminPassword")" -ForegroundColor Green
 
+Write-Host 'Writing README to Desktop; this file contains login information for all C4B services.'
+New-QuickstartReadme
+
+Write-Host 'Cleaning up temporary data'
+Remove-JsonFiles
+
 $Message = 'The CCM, Nexus & Jenkins sites will open in your browser in 10 seconds. Press any key to skip this.'
 $Timeout = New-TimeSpan -Seconds 10
 $Stopwatch = [System.Diagnostics.Stopwatch]::new()
@@ -186,14 +195,15 @@ $Stopwatch.Stop()
 
 if (-not ($keyInfo)) {
     Write-Host "`nOpening CCM, Nexus & Jenkins sites in your browser." -ForegroundColor Green
+    $Readme = 'file:///C:/Users/Public/Desktop/README.html'
     $Ccm = "https://${hostname}/Account/Login"
     $Nexus = "https://${hostname}:8443/#browse/browse"
     $Jenkins = 'http://localhost:8080'
     try {
-        Start-Process msedge.exe "$Ccm", "$Nexus", "$Jenkins"
+        Start-Process msedge.exe "$Readme","$Ccm", "$Nexus", "$Jenkins"
     }
     catch {
-        Start-Process chrome.exe "$Ccm", "$Nexus", "$Jenkins"
+        Start-Process chrome.exe "$Readme","$Ccm", "$Nexus", "$Jenkins"
     }
 }
 

--- a/scripts/Get-Helpers.ps1
+++ b/scripts/Get-Helpers.ps1
@@ -1120,3 +1120,119 @@ ALTER ROLE [$DatabaseRole] ADD MEMBER [$Username]
     $Connection.Close()
 }
 #endregion
+
+#region README functions
+function Remove-JsonFiles {
+    <#
+.SYNOPSIS
+Removes unnecessary json data files from the system upon completion of the Quickstart Guide.
+.PARAMETER JsonPath
+The path to the JSON data files. Defaults to 'C:\choco-setup\logs'.
+.EXAMPLE
+./Start-C4bCleanup.ps1
+.EXAMPLE
+./Start-C4bCleanup.ps1 -JsonPath C:\Temp\
+#>
+
+
+    [CmdletBinding()]
+    Param(
+        [Parameter()]
+        [String]
+        $JsonPath = "$env:SystemDrive\choco-setup\logs"
+    )
+
+    process {
+
+        Get-Child-Item $JsonPath  -Filter '*.json' | Foreach-Object { Remove-Item $_ -Force }
+    }
+}
+
+Function New-QuickstartReadme {
+    <#
+.SYNOPSIS
+Generates a desktop README file containing service information for all services provisioned as part of the Quickstart Guide.
+.PARAMETER HostName
+The host name of the C4B instance.
+.EXAMPLE
+./New-QuickstartReadme.ps1
+.EXAMPLE
+./New-QuickstartReadme.ps1 -HostName c4b.example.com
+#>
+    [CmdletBinding()]
+    Param(
+        [Parameter()]
+        [string]
+        $HostName = $(Get-Content "$env:SystemDrive\choco-setup\logs\ssl.json" | ConvertFrom-Json).CertSubject
+
+    )
+
+
+    process {
+        $nexusPassword = Get-Content -Path 'C:\ProgramData\sonatype-work\nexus3\admin.password'
+        $jenkinsPassword = Get-Content -path 'C:\Program Files (x86)\Jenkins\secrets\initialAdminPassword'
+        $nexusApiKey = (Get-Content "$env:SystemDrive\choco-setup\logs\nexus.json" | ConvertFrom-Json).NuGetApiKey
+
+        $tableData = @([pscustomobject]@{
+                Name     = 'Nexus'
+                Url      = "https://${HostName}:8443"
+                Username = "admin"
+                Password = $nexusPassword
+                ApiKey = $nexusApiKey
+            },
+            [pscustomobject]@{
+                Name     = 'Central Management'
+                Url      = "https://${HostName}"
+                Username = "ccmadmin"
+                Password = '123qwe'
+            },
+            [PSCustomObject]@{
+                Name     = 'Jenkins'
+                Url      = "http://${HostName}:8080"
+                Username = "admin"
+                Password = $jenkinsPassword
+            }
+        )
+
+
+        $html = @"
+    <html>
+    <head>
+    </head>
+    <title>Chocolatey For Business Service Defaults</title>
+    <style>
+    table {
+        border-collapse: collapse;
+    }
+    td,
+    th {
+        border: 0.1em solid rgba(0, 0, 0, 0.5);
+        padding: 0.25em 0.5em;
+        text-align: center;
+    }
+    blockquote {
+        margin-left: 0.5em;
+        padding-left: 0.5em;
+        border-left: 0.1em solid rgba(0, 0, 0, 0.5);
+    }</style>
+    <body>
+    <blockquote>
+<p>📝 <strong>Note</strong></p>
+<p>The following table provides the default credentials to login to each of the services made available as part of the Quickstart Guide setup process.</p> 
+You'll be asked to change the credentials upon logging into each service for the first time.
+Document your new credentials in a password manager, or whatever system you use.
+</p>
+</blockquote>
+    $(($TableData | ConvertTo-Html -Fragment))
+    </body>
+    </html>
+"@
+
+        $folder = Join-Path $env:Public 'Desktop'
+        $file = Join-Path $folder 'README.html'
+
+        $html | Set-Content $file
+
+    }
+}
+#endregion


### PR DESCRIPTION
Closes #46 .

Enhancement:
- Creates a README on the Desktop, with login credentials to CCM, Nexus, and Jenkins
- Opens up README in a browser, adding to CCM, Nexus, and Jenkins that already open
- Cleans up JSON files

This is a cleanup PR based on all the hard work done by @steviecoaster in a PR we had to close off due to merge conflict.

Changes have been tested and are ready for review and merge.