### PR TITLE
Updated remove-json to fix filename resolution

### DIFF
--- a/scripts/Get-Helpers.ps1
+++ b/scripts/Get-Helpers.ps1
@@ -1101,7 +1101,7 @@ The path to the JSON data files. Defaults to 'C:\choco-setup\logs'.
 
     process {
 
-        Get-ChildItem $JsonPath  -Filter '*.json' | Foreach-Object { Remove-Item $_ -Force }
+        Get-ChildItem $JsonPath  -Filter '*.json' | Foreach-Object { Remove-Item $_.FullName -Force }
     }
 }
 


### PR DESCRIPTION
Closes #57.

Resolves the issue of filenames not being available to remove when cleaning up JSON files. Does so by calling the full filenames explicitly (`Remove-Item $_.FullName -Force`).