### PR TITLE
(#58) Update ChocolateyInternal source after SSL setup

### DIFF
--- a/Set-SslSecurity.ps1
+++ b/Set-SslSecurity.ps1
@@ -98,6 +98,11 @@ process {
     } until($response.StatusCode -eq '200')
     Write-Host "Nexus is ready!"
 
+    # Update Repository URI
+    choco source remove --name="'ChocolateyInternal'"
+    $RepositoryUrl = "https://${SubjectWithoutCn}:8443/repository/ChocolateyInternal/"
+    choco source add --name="'ChocolateyInternal'" --source="'$RepositoryUrl'" --allow-self-service --priority=1
+
     #Stop Central Management components
     Stop-Service chocolatey-central-management
     Get-Process chocolateysoftware.chocolateymanagement.web* | Stop-Process -ErrorAction SilentlyContinue -Force

--- a/Set-SslSecurity.ps1
+++ b/Set-SslSecurity.ps1
@@ -101,7 +101,7 @@ process {
     # Update Repository URI
     choco source remove --name="'ChocolateyInternal'"
     $RepositoryUrl = "https://${SubjectWithoutCn}:8443/repository/ChocolateyInternal/"
-    choco source add --name="'ChocolateyInternal'" --source="'$RepositoryUrl'" --allow-self-service --priority=1
+    choco source add --name="'ChocolateyInternal'" --source="'$RepositoryUrl'" --priority=1
 
     #Stop Central Management components
     Stop-Service chocolatey-central-management


### PR DESCRIPTION
Closes #58.

Removes the previous `ChocolateyInternal` source that referenced the old `localhost` URI, which is setup in the Nexus script.

Adds the newly-updated URI for the `ChocolateyInternal` source repository, incorporating the SSL/hostname-based URI changes from the SSL setup script.