### PR TITLE
(#63) Added dependency of dontetcore-sdk for CCM DB pkg

### DIFF
--- a/Start-C4bCcmSetup.ps1
+++ b/Start-C4bCcmSetup.ps1
@@ -90,6 +90,10 @@ choco pin add --name="'aspnetcore-runtimepackagestore'" --version="'3.1.16'" --r
 choco pin add --name="'dotnetcore-windowshosting'" --version="'3.1.16'" --reason="'Required for CCM website'"
 # "reason" only available in commercial editions
 
+# Starting with v0.6.2 of the CCM Database package, it uses dotnetcore-sdk so that it may be installed on a system without requiring IIS.
+# At the time of publishing, the most recent version of this package is 3.1.410, but later package versions (within the 3.x.x release) are expected to work
+choco install dotnetcore-sdk --version 3.1.410 --source $Ccr
+
 # Install CCM DB package using Local SQL Express
 choco install chocolatey-management-database -y -s $PkgSrc --package-parameters="'/ConnectionString=Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;Trusted_Connection=true;'"
 

--- a/Start-C4bSetup.ps1
+++ b/Start-C4bSetup.ps1
@@ -154,6 +154,10 @@ Foreach-Object {
 # Internalize dotnet4.5.2 for ChocolateyGUI (just in case endpoints need it)
 choco download dotnet4.5.2 --no-progress --force --internalize --internalize-all-urls --append-use-original-location --source $Ccr  --output-directory $PkgsDir
 
+# Starting with v0.6.2 of the CCM Database package, it uses dotnetcore-sdk so that it may be installed on a system without requiring IIS.
+# At the time of publishing, the most recent version of this package is 3.1.410, but later package versions (within the 3.x.x release) are expected to work.
+choco download dotnetcore-sdk --version 3.1.410 --force --internalize --internalize-all-urls --append-use-original-location --source $Ccr  --output-directory $PkgsDir
+
 # Download Licensed Packages
 ## DO NOT RUN WITH `--internalize` and `--internalize-all-urls` - see https://github.com/chocolatey/chocolatey-licensed-issues/issues/155
 @('chocolatey-agent', 'chocolatey.extension', 'chocolateygui.extension', 'chocolatey-management-database', 'chocolatey-management-service', 'chocolatey-management-web') |

--- a/Start-C4bSetup.ps1
+++ b/Start-C4bSetup.ps1
@@ -154,10 +154,6 @@ Foreach-Object {
 # Internalize dotnet4.5.2 for ChocolateyGUI (just in case endpoints need it)
 choco download dotnet4.5.2 --no-progress --force --internalize --internalize-all-urls --append-use-original-location --source $Ccr  --output-directory $PkgsDir
 
-# Starting with v0.6.2 of the CCM Database package, it uses dotnetcore-sdk so that it may be installed on a system without requiring IIS.
-# At the time of publishing, the most recent version of this package is 3.1.410, but later package versions (within the 3.x.x release) are expected to work.
-choco download dotnetcore-sdk --version 3.1.410 --force --internalize --internalize-all-urls --append-use-original-location --source $Ccr  --output-directory $PkgsDir
-
 # Download Licensed Packages
 ## DO NOT RUN WITH `--internalize` and `--internalize-all-urls` - see https://github.com/chocolatey/chocolatey-licensed-issues/issues/155
 @('chocolatey-agent', 'chocolatey.extension', 'chocolateygui.extension', 'chocolatey-management-database', 'chocolatey-management-service', 'chocolatey-management-web') |


### PR DESCRIPTION
Close #63.

This is based on work originally done by @ryanrichter94, so full credit to him. 🙌🏼 

This PR adds the installation of the `dotnetcore-sdk` package to the `Start-C4bCcmSetup.ps1` script, as it is now required as a dependency for setup of the CCM DB package.

Code has been tested and is ready for review.