### PR TITLE
(#67) Added -y confirmation for dotnetcore-sdk install

### DIFF
--- a/Start-C4bCcmSetup.ps1
+++ b/Start-C4bCcmSetup.ps1
@@ -92,7 +92,7 @@ choco pin add --name="'dotnetcore-windowshosting'" --version="'3.1.16'" --reason
 
 # Starting with v0.6.2 of the CCM Database package, it uses dotnetcore-sdk so that it may be installed on a system without requiring IIS.
 # At the time of publishing, the most recent version of this package is 3.1.410, but later package versions (within the 3.x.x release) are expected to work
-choco install dotnetcore-sdk --version 3.1.410 --source $Ccr
+choco install dotnetcore-sdk --version 3.1.410 --source $Ccr --no-progress -y
 
 # Install CCM DB package using Local SQL Express
 choco install chocolatey-management-database -y -s $PkgSrc --package-parameters="'/ConnectionString=Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;Trusted_Connection=true;'"


### PR DESCRIPTION
Close #67.

Adds confirmation (`--no-progress -y`) for the dotnecore-sdk package installation in `Start-C4bCcmSetup.ps1` script, to remove the need to interact with the script.

Tested and ready for review and merge.