### PR TITLE
(#70) Added correct apikey for ChocolateyInternal repo

### DIFF
--- a/Set-SslSecurity.ps1
+++ b/Set-SslSecurity.ps1
@@ -38,7 +38,10 @@ param(
     # Ignored/unused if a certificate thumbprint or subject is supplied.
     [Parameter()]
     [string]
-    $Hostname = [System.Net.Dns]::GetHostName()
+    $Hostname = [System.Net.Dns]::GetHostName(),
+
+    # API key of your Nexus repo, to add to the source setup on C4B Server.
+    [string]$NuGetApiKey = $(Get-Content "$env:SystemDrive\choco-setup\logs\nexus.json" | ConvertFrom-Json).NuGetApiKey
 )
 
 begin {
@@ -102,6 +105,7 @@ process {
     choco source remove --name="'ChocolateyInternal'"
     $RepositoryUrl = "https://${SubjectWithoutCn}:8443/repository/ChocolateyInternal/"
     choco source add --name="'ChocolateyInternal'" --source="'$RepositoryUrl'" --priority=1
+    choco apikey --source="'$RepositoryUrl'" --apikey $NuGetApiKey
 
     #Stop Central Management components
     Stop-Service chocolatey-central-management

--- a/Set-SslSecurity.ps1
+++ b/Set-SslSecurity.ps1
@@ -105,7 +105,8 @@ process {
     choco source remove --name="'ChocolateyInternal'"
     $RepositoryUrl = "https://${SubjectWithoutCn}:8443/repository/ChocolateyInternal/"
     choco source add --name="'ChocolateyInternal'" --source="'$RepositoryUrl'" --priority=1
-    $ChocoArgs = @{
+$chocoArgs = @('apikey',"--source='$RepositoryUrl'","--api-key='$NuGetApiKey'")
+& choco @chocoArgs
         source = $RepositoryUrl
         apikey = $NuGetApiKey
         }

--- a/Set-SslSecurity.ps1
+++ b/Set-SslSecurity.ps1
@@ -101,11 +101,15 @@ process {
     } until($response.StatusCode -eq '200')
     Write-Host "Nexus is ready!"
 
-    # Update Repository URI
+    # Update Repository URI and API key
     choco source remove --name="'ChocolateyInternal'"
     $RepositoryUrl = "https://${SubjectWithoutCn}:8443/repository/ChocolateyInternal/"
     choco source add --name="'ChocolateyInternal'" --source="'$RepositoryUrl'" --priority=1
-    choco apikey --source="'$RepositoryUrl'" --apikey $NuGetApiKey
+    $ChocoArgs = @{
+        source = $RepositoryUrl
+        apikey = $NuGetApiKey
+        }
+    & choco apikey @ChocoArgs
 
     #Stop Central Management components
     Stop-Service chocolatey-central-management

--- a/Start-C4bNexusSetup.ps1
+++ b/Start-C4bNexusSetup.ps1
@@ -59,7 +59,6 @@ Get-ChildItem -Path "$env:SystemDrive\choco-setup\packages" -Filter *.nupkg |
 
 # Add ChooclateyInternal as a source repository
 choco source add -n 'ChocolateyInternal' -s "$((Get-NexusRepository -Name 'ChocolateyInternal').url)/" --priority 1
-choco apikey -s 'ChocolateyInternal' -k $NugetApiKey
 
 # Install a non-IE browser for browsing the Nexus web portal.
 # Edge sometimes fails install due to latest Windows Updates not being installed.


### PR DESCRIPTION
Closes #70.

Following changes made:
- Added `choco apikey` command in `Set-SSLSecurity.ps1` script, to enable user to push packages on C4B server with Package Uploader.
- Removed `choco apikey` command in `Start-C4bNexusSetup.ps1` script, as this is not used in any other commands at this point, and could interfere with the setting of it later.

Tested on WS 2019, and ready for review and merge.