### PR TITLE
(#70)Removed redundant apikey command in SSL script

### DIFF
--- a/Set-SslSecurity.ps1
+++ b/Set-SslSecurity.ps1
@@ -105,12 +105,8 @@ process {
     choco source remove --name="'ChocolateyInternal'"
     $RepositoryUrl = "https://${SubjectWithoutCn}:8443/repository/ChocolateyInternal/"
     choco source add --name="'ChocolateyInternal'" --source="'$RepositoryUrl'" --priority=1
-$chocoArgs = @('apikey',"--source='$RepositoryUrl'","--api-key='$NuGetApiKey'")
-& choco @chocoArgs
-        source = $RepositoryUrl
-        apikey = $NuGetApiKey
-        }
-    & choco apikey @ChocoArgs
+    $chocoArgs = @('apikey',"--source='$RepositoryUrl'","--api-key='$NuGetApiKey'")
+    & choco @chocoArgs
 
     #Stop Central Management components
     Stop-Service chocolatey-central-management


### PR DESCRIPTION
Closes #70.

We had a redundant `choco apikey`command written in 2 different methods in the `Set-SSLSecurity.ps1` script.

This removes the redundant command.