### PR TITLE
(#56) - Added hardening with Nexus Cred & Salts for CCM

### DIFF
--- a/Set-SslSecurity.ps1
+++ b/Set-SslSecurity.ps1
@@ -155,9 +155,9 @@ process {
         }
 
         if (-not (Get-NexusUser -User 'chocouser')) {
-        $NexusPw = [System.Web.Security.Membership]::GeneratePassword(32, 12)
-        # Create Nexus user
-        $UserParams = @{
+            $NexusPw = [System.Web.Security.Membership]::GeneratePassword(32, 12)
+            # Create Nexus user
+            $UserParams = @{
                 Username     = 'chocouser'
                 Password     = ($NexusPw | ConvertTo-SecureString -AsPlainText -Force)
                 FirstName    = 'Choco'

--- a/Set-SslSecurity.ps1
+++ b/Set-SslSecurity.ps1
@@ -143,7 +143,7 @@ process {
         # Disable anonymous authentication
         Set-NexusAnonymousAuth -Disabled
         
-        if (-not (Get-NexusRole -Role 'chocorole')) {
+        if (-not (Get-NexusRole -Role 'chocorole' -ErrorAction SilentlyContinue)) {
             # Create Nexus role
             $RoleParams = @{
                 Id          = "chocorole"
@@ -154,7 +154,7 @@ process {
             New-NexusRole @RoleParams
         }
 
-        if (-not (Get-NexusUser -User 'chocouser')) {
+        if (-not (Get-NexusUser -User 'chocouser' -ErrorAction SilentlyContinue)) {
             $NexusPw = [System.Web.Security.Membership]::GeneratePassword(32, 12)
             # Create Nexus user
             $UserParams = @{

--- a/Start-C4bJenkinsSetup.ps1
+++ b/Start-C4bJenkinsSetup.ps1
@@ -197,7 +197,7 @@ if (-not ($keyInfo)) {
     Write-Host "`nOpening CCM, Nexus & Jenkins sites in your browser." -ForegroundColor Green
     $Readme = 'file:///C:/Users/Public/Desktop/README.html'
     $Ccm = "https://${hostname}/Account/Login"
-    $Nexus = "https://${hostname}:8443/#browse/browse"
+    $Nexus = "https://${hostname}:8443"
     $Jenkins = 'http://localhost:8080'
     try {
         Start-Process msedge.exe "$Readme","$Ccm", "$Nexus", "$Jenkins"


### PR DESCRIPTION
Closes #56.

Adds Internet hardening to the C4B Server, when the `-Hardened` parameter has been passed to the `Set-SslSecurity.ps1` script. This will perform the following:
- Adds a role and user credential to the Nexus server, which is used to authenticate the source setup on a client endpoint.
- Adds a Client and Service Salt to further secure the SSL connection with CCM.
- Updates the Register-C4bEndpoint.ps1 script to use these new credentials.

Tested and ready for review. QSG doc should also reference the `-Hardened` parameter for the `Set-SslSecurity.ps1` script; this will, of course, be done in a separate PR against that repo.