### PR TITLE
(#60) Provision Chocolatey Agent on server

### DIFF
--- a/Set-SslSecurity.ps1
+++ b/Set-SslSecurity.ps1
@@ -209,7 +209,7 @@ process {
         $IsSelfSigned = $true
         .\scripts\New-IISCertificateHost.ps1
     }
-
+    
     # Generate Register-C4bEndpoint.ps1
     $EndpointScript = "$ScriptDir\Register-C4bEndpoint.ps1"
 
@@ -247,9 +247,27 @@ process {
 "@
 
         $ScriptBlock | Set-Content -Path $EndpointScript
+
+        #Agent Setup
+        $agentArgs = @{
+            CentralManagementServiceUrl = "https://$($SubjectWithoutCn):24020/ChocolateyManagementService"
+            ServiceSalt = $ServiceSaltValue
+            ClientSalt = $ClientSaltValue
+        }
+
+        Install-ChocolateyAgent @agentArgs
     }
 
     else {
+
+         #Agent Setup
+         $agentArgs = @{
+            CentralManagementServiceUrl = "https://$($SubjectWithoutCn):24020/ChocolateyManagementService"
+        }
+
+        Install-ChocolateyAgent @agentArgs
+
+        #Register endpoint script
         (Get-Content -Path $EndpointScript) -replace "{{hostname}}", "'$SubjectWithoutCn'" | Set-Content -Path $EndpointScript
         if ($IsSelfSigned) {
             $ScriptBlock = @"

--- a/scripts/Get-Helpers.ps1
+++ b/scripts/Get-Helpers.ps1
@@ -1678,3 +1678,55 @@ Document your new credentials in a password manager, or whatever system you use.
     }
 }
 #endregion
+
+#region Agent Setup
+function Install-ChocolateyAgent {
+    [CmdletBinding()]
+    Param(
+        [Parameter()]
+        [String]
+        $Source,
+
+        [Parameter(Mandatory)]
+        [String]
+        $CentralManagementServiceUrl,
+
+        [Parameter()]
+        [String]
+        $ServiceSalt,
+
+        [Parameter()]
+        [String]
+        $ClientSalt
+    )
+
+    process {
+        if($Source){
+            $chocoArgs = @('install','chocolatey-agent','-y',"--source='$Source'")
+            & choco @chocoArgs
+        }
+        else {
+            $chocoArgs = @('install','chocolatey-agent','-y')
+            & choco @chocoArgs
+        }
+        
+
+        $chocoArgs = @('config','set','centralMangementServiceUrl',"$CentralManagementServiceUrl")
+        & choco @chocoArgs
+
+        $chocoArgs = @('feature','enable','--name="useChocolateyCentralManagement"')
+        & choco @chocoArgs
+
+        $chocoArgs = @('feature','enable','--name="useChocolateyCentralManagementDeployments"')
+        & choco @chocoArgs
+
+        if($ServiceSalt -and $ClientSalt){
+            $chocoArgs = @('config','set','centralManagementClientCommunicationSaltAdditivePassword',"$ClientSalt")
+            & choco @chocoArgs
+
+            $chocoArgs = @('config','set','centralManagementServiceCommunicationSaltAdditivePassword',"$ServiceSalt")
+            & choco @chocoArgs
+        }
+    }
+}
+#endregion


### PR DESCRIPTION
This PR addresses configuring the Chocolatey Agent service on the server. If hardened, the agent will be provisioned with additional salt configuration, otherwise a default Agent installation will be performed with Central Management enabled.

Fixes #60