### PR TITLE
Added -UseBasicParsing  to nexus startup check

### DIFF
--- a/Set-SslSecurity.ps1
+++ b/Set-SslSecurity.ps1
@@ -106,7 +106,7 @@ process {
     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::tls12
     do {
         $response = try {
-            Invoke-WebRequest "https://${SubjectWithoutCn}:8443" -ErrorAction Stop
+            Invoke-WebRequest "https://${SubjectWithoutCn}:8443" -UseBasicParsing -ErrorAction Stop
             Start-Sleep -Seconds 3
         }
         catch {


### PR DESCRIPTION
Without -UseBasicParsing on hardened systems (e.g. IE disabled), Invoke-WebRequest throws the error: "The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again."