### PR TITLE
Fix typo in choco args for agent setup

### DIFF
--- a/scripts/Get-Helpers.ps1
+++ b/scripts/Get-Helpers.ps1
@@ -1711,7 +1711,7 @@ function Install-ChocolateyAgent {
         }
         
 
-        $chocoArgs = @('config','set','centralMangementServiceUrl',"$CentralManagementServiceUrl")
+        $chocoArgs = @('config','set','centralManagementServiceUrl',"$CentralManagementServiceUrl")
         & choco @chocoArgs
 
         $chocoArgs = @('feature','enable','--name="useChocolateyCentralManagement"')


### PR DESCRIPTION
This appeared to work, but was setting a config value that doesn't actually exist for anything useful
due to a typo.

This fixes the typo, and sets the correct config entry to the right value

Fixes #92 