### PR TITLE
(#90) Prevent execution in PowerShell ISE

### DIFF
--- a/Set-SslSecurity.ps1
+++ b/Set-SslSecurity.ps1
@@ -53,17 +53,20 @@ param(
 )
 
 begin {
+    if($host.name -ne 'ConsoleHost') {
+        Write-Warning "This script cannot be ran from within PowerShell ISE"
+        Write-Warning "Please launch powershell.exe as an administrator, and run this script again"
+        break
+    }
+}
 
+process {
     $DefaultEap = $ErrorActionPreference
     $ErrorActionPreference = 'Stop'
     Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Set-SslCertificate-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
     
     # Dot-source helper functions
     . .\scripts\Get-Helpers.ps1
-}
-
-process {
-
     #Collect current certificate configuration
     $Certificate = if ($Subject) {
         Get-Certificate -Subject $Subject

--- a/Start-C4bCcmSetup.ps1
+++ b/Start-C4bCcmSetup.ps1
@@ -17,153 +17,164 @@ param(
     $DatabaseCredential = (Get-Credential -Username ChocoUser -Message 'Create a credential for the ChocolateyManagement DB user (document this somewhere)')
 )
 
-$DefaultEap = $ErrorActionPreference
-$ErrorActionPreference = 'Stop'
-Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Start-C4bCcmSetup-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
-
-# Dot-source helper functions
-. .\scripts\Get-Helpers.ps1
-
-# DB Setup
-$PkgSrc = "$env:SystemDrive\choco-setup\packages"
-$Ccr = 'https://community.chocolatey.org/api/v2/'
-
-$chocoArgs = @('upgrade', 'sql-server-express', 'sql-server-management-studio', '-y', "--source='$Ccr'", '--no-progress')
-& choco @chocoArgs
-
-# https://docs.microsoft.com/en-us/sql/tools/configuration-manager/tcp-ip-properties-ip-addresses-tab
-Write-Output 'SQL Server: Configuring Remote Acess on SQL Server Express.'
-$assemblyList = 'Microsoft.SqlServer.Management.Common', 'Microsoft.SqlServer.Smo', 'Microsoft.SqlServer.SqlWmiManagement', 'Microsoft.SqlServer.SmoExtended'
-
-foreach ($assembly in $assemblyList) {
-    $assembly = [System.Reflection.Assembly]::LoadWithPartialName($assembly)
-}
-
-$wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer # connects to localhost by default
-$instance = $wmi.ServerInstances | Where-Object { $_.Name -eq 'SQLEXPRESS' }
-
-$np = $instance.ServerProtocols | Where-Object { $_.Name -eq 'Np' }
-$np.IsEnabled = $true
-$np.Alter()
-
-$tcp = $instance.ServerProtocols | Where-Object { $_.Name -eq 'Tcp' }
-$tcp.IsEnabled = $true
-$tcp.Alter()
-
-$tcpIpAll = $tcp.IpAddresses | Where-Object { $_.Name -eq 'IpAll' }
-
-$tcpDynamicPorts = $tcpIpAll.IpAddressProperties | Where-Object { $_.Name -eq 'TcpDynamicPorts' }
-$tcpDynamicPorts.Value = ""
-$tcp.Alter()
-
-$tcpPort = $tcpIpAll.IpAddressProperties | Where-Object { $_.Name -eq 'TcpPort' }
-$tcpPort.Value = "1433"
-$tcp.Alter()
-
-# This section will evaluate which version of SQL Express you have installed, and set a login value accordingly
-$SqlString = (Get-ChildItem -Path 'HKLM:\Software\Microsoft\Microsoft SQL Server').Name |
-    Where-Object { $_ -like "HKEY_LOCAL_MACHINE\Software\Microsoft\Microsoft SQL Server\MSSQL*.SQLEXPRESS" } 
-$SqlVersion = $SqlString.Split("\") | Where-Object { $_ -like "MSSQL*.SQLEXPRESS" }
-Write-Output 'SQL Server: Setting Mixed Mode Authentication.'
-New-ItemProperty "HKLM:\Software\Microsoft\Microsoft SQL Server\$SqlVersion\MSSQLServer\" -Name 'LoginMode' -Value 2 -Force
-
-Write-Output "SQL Server: Forcing Restart of Instance."
-Restart-Service -Force 'MSSQL$SQLEXPRESS'
-
-Write-Output "SQL Server: Setting up SQL Server Browser and starting the service."
-Set-Service 'SQLBrowser' -StartupType Automatic
-Start-Service 'SQLBrowser'
-
-Write-Output "Firewall: Enabling SQLServer TCP port 1433."
-netsh advfirewall firewall add rule name="SQL Server 1433" dir=in action=allow protocol=TCP localport=1433 profile=any enable=yes service=any
-#New-NetFirewallRule -DisplayName "Allow inbound TCP Port 1433" –Direction inbound –LocalPort 1433 -Protocol TCP -Action Allow
-
-Write-Output "Firewall: Enabling SQL Server browser UDP port 1434."
-netsh advfirewall firewall add rule name="SQL Server Browser 1434" dir=in action=allow protocol=UDP localport=1434 profile=any enable=yes service=any
-#New-NetFirewallRule -DisplayName "Allow inbound UDP Port 1434" –Direction inbound –LocalPort 1434 -Protocol UDP -Action Allow
-
-# Install prerequisites for CCM
-$chocoArgs = @('install', 'IIS-WebServer', "--source='windowsfeatures'", '--no-progress', '-y')
-& choco @chocoArgs
-
-$chocoArgs = @('install', 'IIS-ApplicationInit', "--source='windowsfeatures'" ,'--no-progress', '-y')
-& choco @chocoArgs
-
-$chocoArgs = @('install', 'aspnetcore-runtimepackagestore', "--version='3.1.16'", "--source='$Ccr'", '--no-progress', '-y')
-& choco @chocoArgs
-
-$chocoArgs = @('install', 'dotnetcore-windowshosting', "--version='3.1.16'", "--source='$Ccr'", '--no-progress', '-y')
-& choco @chocoArgs
-
-choco pin add --name="'aspnetcore-runtimepackagestore'" --version="'3.1.16'" --reason="'Required for CCM website'"
-choco pin add --name="'dotnetcore-windowshosting'" --version="'3.1.16'" --reason="'Required for CCM website'"
-# "reason" only available in commercial editions
-
-# Starting with v0.6.2 of the CCM Database package, it uses dotnetcore-sdk so that it may be installed on a system without requiring IIS.
-# At the time of publishing, the most recent version of this package is 3.1.410, but later package versions (within the 3.x.x release) are expected to work
-choco install dotnetcore-sdk --version 3.1.410 --source $Ccr --no-progress -y
-
-# Install CCM DB package using Local SQL Express
-choco install chocolatey-management-database -y -s $PkgSrc --package-parameters="'/ConnectionString=Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;Trusted_Connection=true;'" --no-progress
-
-# Add Local Windows User:
-$DatabaseUser = $DatabaseCredential.UserName
-$DatabaseUserPw = $DatabaseCredential.GetNetworkCredential().Password
-Add-DatabaseUserAndRoles -DatabaseName 'ChocolateyManagement' -Username $DatabaseUser -SqlUserPw $DatabaseUserPw -CreateSqlUser -DatabaseRoles @('db_datareader', 'db_datawriter')
-
-# Find FDQN for current machine
-$hostName = [System.Net.Dns]::GetHostName()
-$domainName = [System.Net.NetworkInformation.IPGlobalProperties]::GetIPGlobalProperties().DomainName
-
-if(-Not $hostName.endswith($domainName)) {
-    $hostName += "." + $domainName
-}
-
-#Install CCM Service
-$chocoArgs = @('install', 'chocolatey-management-service', '-y', "--source='$PkgSrc'", "--package-parameters-sensitive='/ConnectionString:Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;User ID=$DatabaseUser;Password=$DatabaseUserPw;'", '--no-progress')
-& choco @chocoArgs
-
-# Check if OS is 2016. If so, let the user know
-# they need a reboot after IIS packages install.
-# Instruct user to run secondary script after reboot.
-$Os = (Get-ItemProperty -Path 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion' -Name ProductName).ProductName
-if ($Os -like '*2016*') {
-    $CcmSvcUrl = choco config get centralManagementServiceUrl -r
-    $CcmJson = @{
-        CCMServiceURL        = $CcmSvcUrl
-        CCMWebPortal         = "http://localhost/Account/Login"
-        DefaultUser          = "ccmadmin"
-        DefaultPwToBeChanged = "123qwe"
-        CCMDBUser            = $DatabaseUser
-        CCMDBPassword        = $DatabaseUserPw
+begin {
+    if($host.name -ne 'ConsoleHost') {
+        Write-Warning "This script cannot be ran from within PowerShell ISE"
+        Write-Warning "Please launch powershell.exe as an administrator, and run this script again"
+        break
     }
-    $CcmJson | ConvertTo-Json | Out-File "$env:SystemDrive\choco-setup\logs\ccm.json"
-    $ErrorActionPreference = $DefaultEap
-    Stop-Transcript
-    $Comment = @"
-Chocolatey has detected that your operating system is Windows Server 2016.
-In order to complete the installation of IIS, a restart is required.
-This server will restart in 30 seconds. Once restarted, please follow
-the steps outlined in the C4B Quick-Start Guide to contiue.
+}
+
+
+process {
+    $DefaultEap = $ErrorActionPreference
+    $ErrorActionPreference = 'Stop'
+    Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Start-C4bCcmSetup-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
+
+    # Dot-source helper functions
+    . .\scripts\Get-Helpers.ps1
+
+    # DB Setup
+    $PkgSrc = "$env:SystemDrive\choco-setup\packages"
+    $Ccr = 'https://community.chocolatey.org/api/v2/'
+
+    $chocoArgs = @('upgrade', 'sql-server-express', 'sql-server-management-studio', '-y', "--source='$Ccr'", '--no-progress')
+    & choco @chocoArgs
+
+    # https://docs.microsoft.com/en-us/sql/tools/configuration-manager/tcp-ip-properties-ip-addresses-tab
+    Write-Output 'SQL Server: Configuring Remote Acess on SQL Server Express.'
+    $assemblyList = 'Microsoft.SqlServer.Management.Common', 'Microsoft.SqlServer.Smo', 'Microsoft.SqlServer.SqlWmiManagement', 'Microsoft.SqlServer.SmoExtended'
+
+    foreach ($assembly in $assemblyList) {
+        $assembly = [System.Reflection.Assembly]::LoadWithPartialName($assembly)
+    }
+
+    $wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer # connects to localhost by default
+    $instance = $wmi.ServerInstances | Where-Object { $_.Name -eq 'SQLEXPRESS' }
+
+    $np = $instance.ServerProtocols | Where-Object { $_.Name -eq 'Np' }
+    $np.IsEnabled = $true
+    $np.Alter()
+
+    $tcp = $instance.ServerProtocols | Where-Object { $_.Name -eq 'Tcp' }
+    $tcp.IsEnabled = $true
+    $tcp.Alter()
+
+    $tcpIpAll = $tcp.IpAddresses | Where-Object { $_.Name -eq 'IpAll' }
+
+    $tcpDynamicPorts = $tcpIpAll.IpAddressProperties | Where-Object { $_.Name -eq 'TcpDynamicPorts' }
+    $tcpDynamicPorts.Value = ""
+    $tcp.Alter()
+
+    $tcpPort = $tcpIpAll.IpAddressProperties | Where-Object { $_.Name -eq 'TcpPort' }
+    $tcpPort.Value = "1433"
+    $tcp.Alter()
+
+    # This section will evaluate which version of SQL Express you have installed, and set a login value accordingly
+    $SqlString = (Get-ChildItem -Path 'HKLM:\Software\Microsoft\Microsoft SQL Server').Name |
+        Where-Object { $_ -like "HKEY_LOCAL_MACHINE\Software\Microsoft\Microsoft SQL Server\MSSQL*.SQLEXPRESS" } 
+    $SqlVersion = $SqlString.Split("\") | Where-Object { $_ -like "MSSQL*.SQLEXPRESS" }
+    Write-Output 'SQL Server: Setting Mixed Mode Authentication.'
+    New-ItemProperty "HKLM:\Software\Microsoft\Microsoft SQL Server\$SqlVersion\MSSQLServer\" -Name 'LoginMode' -Value 2 -Force
+
+    Write-Output "SQL Server: Forcing Restart of Instance."
+    Restart-Service -Force 'MSSQL$SQLEXPRESS'
+
+    Write-Output "SQL Server: Setting up SQL Server Browser and starting the service."
+    Set-Service 'SQLBrowser' -StartupType Automatic
+    Start-Service 'SQLBrowser'
+
+    Write-Output "Firewall: Enabling SQLServer TCP port 1433."
+    netsh advfirewall firewall add rule name="SQL Server 1433" dir=in action=allow protocol=TCP localport=1433 profile=any enable=yes service=any
+    #New-NetFirewallRule -DisplayName "Allow inbound TCP Port 1433" –Direction inbound –LocalPort 1433 -Protocol TCP -Action Allow
+
+    Write-Output "Firewall: Enabling SQL Server browser UDP port 1434."
+    netsh advfirewall firewall add rule name="SQL Server Browser 1434" dir=in action=allow protocol=UDP localport=1434 profile=any enable=yes service=any
+    #New-NetFirewallRule -DisplayName "Allow inbound UDP Port 1434" –Direction inbound –LocalPort 1434 -Protocol UDP -Action Allow
+
+    # Install prerequisites for CCM
+    $chocoArgs = @('install', 'IIS-WebServer', "--source='windowsfeatures'", '--no-progress', '-y')
+    & choco @chocoArgs
+
+    $chocoArgs = @('install', 'IIS-ApplicationInit', "--source='windowsfeatures'" ,'--no-progress', '-y')
+    & choco @chocoArgs
+
+    $chocoArgs = @('install', 'aspnetcore-runtimepackagestore', "--version='3.1.16'", "--source='$Ccr'", '--no-progress', '-y')
+    & choco @chocoArgs
+
+    $chocoArgs = @('install', 'dotnetcore-windowshosting', "--version='3.1.16'", "--source='$Ccr'", '--no-progress', '-y')
+    & choco @chocoArgs
+
+    choco pin add --name="'aspnetcore-runtimepackagestore'" --version="'3.1.16'" --reason="'Required for CCM website'"
+    choco pin add --name="'dotnetcore-windowshosting'" --version="'3.1.16'" --reason="'Required for CCM website'"
+    # "reason" only available in commercial editions
+
+    # Starting with v0.6.2 of the CCM Database package, it uses dotnetcore-sdk so that it may be installed on a system without requiring IIS.
+    # At the time of publishing, the most recent version of this package is 3.1.410, but later package versions (within the 3.x.x release) are expected to work
+    choco install dotnetcore-sdk --version 3.1.410 --source $Ccr --no-progress -y
+
+    # Install CCM DB package using Local SQL Express
+    choco install chocolatey-management-database -y -s $PkgSrc --package-parameters="'/ConnectionString=Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;Trusted_Connection=true;'" --no-progress
+
+    # Add Local Windows User:
+    $DatabaseUser = $DatabaseCredential.UserName
+    $DatabaseUserPw = $DatabaseCredential.GetNetworkCredential().Password
+    Add-DatabaseUserAndRoles -DatabaseName 'ChocolateyManagement' -Username $DatabaseUser -SqlUserPw $DatabaseUserPw -CreateSqlUser -DatabaseRoles @('db_datareader', 'db_datawriter')
+
+    # Find FDQN for current machine
+    $hostName = [System.Net.Dns]::GetHostName()
+    $domainName = [System.Net.NetworkInformation.IPGlobalProperties]::GetIPGlobalProperties().DomainName
+
+    if(-Not $hostName.endswith($domainName)) {
+        $hostName += "." + $domainName
+    }
+
+    #Install CCM Service
+    $chocoArgs = @('install', 'chocolatey-management-service', '-y', "--source='$PkgSrc'", "--package-parameters-sensitive='/ConnectionString:Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;User ID=$DatabaseUser;Password=$DatabaseUserPw;'", '--no-progress')
+    & choco @chocoArgs
+
+    # Check if OS is 2016. If so, let the user know
+    # they need a reboot after IIS packages install.
+    # Instruct user to run secondary script after reboot.
+    $Os = (Get-ItemProperty -Path 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion' -Name ProductName).ProductName
+    if ($Os -like '*2016*') {
+        $CcmSvcUrl = choco config get centralManagementServiceUrl -r
+        $CcmJson = @{
+            CCMServiceURL        = $CcmSvcUrl
+            CCMWebPortal         = "http://localhost/Account/Login"
+            DefaultUser          = "ccmadmin"
+            DefaultPwToBeChanged = "123qwe"
+            CCMDBUser            = $DatabaseUser
+            CCMDBPassword        = $DatabaseUserPw
+        }
+        $CcmJson | ConvertTo-Json | Out-File "$env:SystemDrive\choco-setup\logs\ccm.json"
+        $ErrorActionPreference = $DefaultEap
+        Stop-Transcript
+        $Comment = @"
+    Chocolatey has detected that your operating system is Windows Server 2016.
+    In order to complete the installation of IIS, a restart is required.
+    This server will restart in 30 seconds. Once restarted, please follow
+    the steps outlined in the C4B Quick-Start Guide to contiue.
 "@
-    Start-Process 'shutdown.exe' -ArgumentList "/r /f /t 30 /c `"$Comment`" /d p:4:1"
-}
-else {
-    #Install CCM Web package
-    choco install chocolatey-management-web -y --package-parameters-sensitive="'/ConnectionString:Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;User ID=$DatabaseUser;Password=$DatabaseUserPw;'" --no-progress
-
-    $CcmSvcUrl = choco config get centralManagementServiceUrl -r
-    $CcmJson = @{
-        CCMServiceURL        = $CcmSvcUrl
-        CCMWebPortal         = "http://localhost/Account/Login"
-        DefaultUser          = "ccmadmin"
-        DefaultPwToBeChanged = "123qwe"
-        CCMDBUser            = $DatabaseUser
+        Start-Process 'shutdown.exe' -ArgumentList "/r /f /t 30 /c `"$Comment`" /d p:4:1"
     }
-    $CcmJson | ConvertTo-Json | Out-File "$env:SystemDrive\choco-setup\logs\ccm.json"
+    else {
+        #Install CCM Web package
+        choco install chocolatey-management-web -y --package-parameters-sensitive="'/ConnectionString:Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;User ID=$DatabaseUser;Password=$DatabaseUserPw;'" --no-progress
 
-    Write-Host "CCM Setup has now completed" -ForegroundColor Green
+        $CcmSvcUrl = choco config get centralManagementServiceUrl -r
+        $CcmJson = @{
+            CCMServiceURL        = $CcmSvcUrl
+            CCMWebPortal         = "http://localhost/Account/Login"
+            DefaultUser          = "ccmadmin"
+            DefaultPwToBeChanged = "123qwe"
+            CCMDBUser            = $DatabaseUser
+        }
+        $CcmJson | ConvertTo-Json | Out-File "$env:SystemDrive\choco-setup\logs\ccm.json"
 
-    $ErrorActionPreference = $DefaultEap
-    Stop-Transcript
+        Write-Host "CCM Setup has now completed" -ForegroundColor Green
+
+        $ErrorActionPreference = $DefaultEap
+        Stop-Transcript
+    }
 }

--- a/Start-C4bJenkinsSetup.ps1
+++ b/Start-C4bJenkinsSetup.ps1
@@ -20,202 +20,213 @@ param(
     [string]$NuGetApiKey = $(Get-Content "$env:SystemDrive\choco-setup\logs\nexus.json" | ConvertFrom-Json).NuGetApiKey
 )
 
-$DefaultEap = $ErrorActionPreference
-$ErrorActionPreference = 'Stop'
-Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Start-C4bJenkinsSetup-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
-
-# Dot-source helper functions
-. .\scripts\Get-Helpers.ps1
-
-# Install Jenkins
-$chocoArgs = @('install', 'jenkins', '-y', "--source='$Source'", '--no-progress',"--version='2.222.4'")
-& choco @chocoArgs
-
-choco pin add --name="'jenkins'" --version="'2.222.4'" --reason="'Next version is a breaking change; see online QDE documentation FAQ'"
-
-Write-Host "Giving Jenkins 30 seconds to complete background setup..." -ForegroundColor Green
-Start-Sleep -Seconds 30  # Jenkins needs a moment
-
-# Long winded way to get the scripts for Jenkins jobs into the right place, but easier to mainntain going forward
-$root = Split-Path -Parent $MyInvocation.MyCommand.Definition
-$systemRoot = $env:SystemDrive + '\'
-$JenkinsRoot = Join-Path $root -ChildPath 'jenkins'
-$jenkinsScripts = Join-Path $JenkinsRoot -ChildPath 'scripts'
-
-Move-Item $jenkinsScripts $systemRoot -Force
-
-Stop-Service -Name Jenkins
-$JenkinsHome = "${env:ProgramFiles(x86)}\Jenkins"
-$JenkinsConfigPath = Join-Path $JenkinsHome "config.xml"
-Copy-Item -Path $JenkinsConfigPath -Destination "$($JenkinsConfigPath).old" -Force
-
-# Ignore "first startup"
-Write-Host "Disabling Jenkins first-run prompts" -ForegroundColor Green
-Get-Content -Path "$($JenkinsConfigPath).old" |
-    Where-Object { $_ -notlike "*<installStateName>*" } |
-    Set-Content -Path $JenkinsConfigPath
-
-Write-Host "Updating Jenkins plugins" -ForegroundColor Green
-$JenkinsPlugins = @{
-    'cloudbees-folder' = '6.15'
-    'trilead-api' = '1.0.13'
-    'antisamy-markup-formatter' = '2.1'
-    'structs' = '1.23'
-    'workflow-step-api' = '2.23'
-    'token-macro' = '2.13'
-    'build-timeout' = '1.20'
-    'credentials' = '2.5'
-    'plain-credentials' = '1.7'
-    'ssh-credentials' = '1.18.1'
-    'credentials-binding' = '1.24'
-    'scm-api' = '2.6.4'
-    'workflow-api' = '2.46'
-    'timestamper' = '1.13'
-    'caffeine-api' = '2.9.1-23.v51c4e2c879c8'
-    'script-security' = '1.77'
-    'plugin-util-api' = '1.7.1'
-    'font-awesome-api' = '5.15.2-1'
-    'popper-api' = '1.16.1-1'
-    'jquery3-api' = '3.5.1-2'
-    'bootstrap4-api' = '4.6.0-1'
-    'snakeyaml-api' = '1.29.1'
-    'jackson2-api' = '2.12.3'
-    'echarts-api' = '4.9.0-3'
-    'display-url-api' = '2.3.5'
-    'workflow-support' = '3.8'
-    'workflow-job' = '2.41'
-    'checks-api' = '1.5.0'
-    'junit' = '1.51'
-    'matrix-project' = '1.18'
-    'resource-disposer' = '0.16'
-    'ws-cleanup' = '0.39'
-    'ant' = '1.11'
-    'durable-task' = '1.37'
-    'workflow-durable-task-step' = '2.35'
-    'command-launcher' = '1.6'
-    'jdk-tool' = '1.5'
-    'bouncycastle-api' = '2.20'
-    'ace-editor' = '1.1'
-    'workflow-scm-step' = '2.13'
-    'workflow-cps' = '2.92'
-    'apache-httpcomponents-client-4-api' = '4.5.13-1.0'
-    'mailer' = '1.32.1'
-    'workflow-basic-steps' = '2.21'
-    'gradle' = '1.36'
-    'pipeline-milestone-step' = '1.3.2'
-    'pipeline-input-step' = '2.12'
-    'pipeline-stage-step' = '2.5'
-    'pipeline-graph-analysis' = '1.11'
-    'pipeline-rest-api' = '2.19'
-    'handlebars' = '3.0.8'
-    'momentjs' = '1.1.1'
-    'pipeline-stage-view' = '2.19'
-    'pipeline-build-step' = '2.13'
-    'pipeline-model-api' = '1.8.5'
-    'pipeline-model-extensions' = '1.8.5'
-    'jsch' = '0.1.55.2'
-    'git-client' = '3.6.0'
-    'git-server' = '1.9'
-    'workflow-cps-global-lib' = '2.19'
-    'branch-api' = '2.6.2'
-    'workflow-multibranch' = '2.24'
-    'pipeline-stage-tags-metadata' = '1.8.5'
-    'pipeline-model-definition' = '1.8.5'
-    'lockable-resources' = '2.11'
-    'workflow-aggregator' = '2.6'
-    'jjwt-api' = '0.11.2-9.c8b45b8bb173'
-    'okhttp-api' = '3.14.9'
-    'github-api' = '1.123'
-    'git' = '4.6.0'
-    'github' = '1.33.1'
-    'github-branch-source' = '2.9.9'
-    'pipeline-github-lib' = '1.0'
-    'mapdb-api' = '1.0.9.0'
-    'subversion' = '2.14.4'
-    'ssh-slaves' = '1.31.5'
-    'matrix-auth' = '2.6.7'
-    'pam-auth' = '1.6'
-    'ldap' = '1.25'
-    'email-ext' = '2.83'
-    'powershell' = '1.5'
-}
-
-foreach ($PluginName in $JenkinsPlugins.Keys) {
-    $PluginUri = 'https://updates.jenkins-ci.org/download/plugins/{0}/{1}/{0}.hpi' -f $PluginName,$JenkinsPlugins[$PluginName]
-    $PluginPath = '{0}/plugins/{1}.hpi' -f $JenkinsHome, $PluginName
-    [System.Net.WebClient]::New().DownloadFile($PluginUri,$PluginPath)
-}
-
-#region Job Config
-Write-Host "Creating Chocolatey Jobs" -ForegroundColor Green
-Get-ChildItem "$env:SystemDrive\choco-setup\files\jenkins" | Copy-Item -Destination "$JenkinsHome\jobs\" -Recurse
-
-
-Get-ChildItem -Path "$JenkinsHome\jobs" -Recurse -File -Filter 'config.xml' | ForEach-Object {
-    (Get-Content -Path $_.FullName -Raw) -replace
-        '{{NugetApiKey}}', $NuGetApiKey -replace
-        '{{hostname}}', $HostName |
-        Set-Content -Path $_.FullName
-}
-#endregion
-
-Write-Host "Starting Jenkins service back up" -ForegroundColor Green
-Start-Service -Name Jenkins
-
-# Save useful params to JSON
-$JenkinsJson = @{
-    JenkinsUri = "http://localhost:8080"
-    JenkinsUser = "admin"
-    JenkinsPw = $(Get-Content "${env:ProgramFiles(x86)}\Jenkins\secrets\initialAdminPassword")
-}
-$JenkinsJson | ConvertTo-Json | Out-File "$env:SystemDrive\choco-setup\logs\jenkins.json"
-
-Write-Host 'Jenkins setup complete' -ForegroundColor Green
-Write-Host 'Login to Jenkins at: http://locahost:8080' -ForegroundColor Green
-Write-Host 'Initial default Jenkins admin user password:' -ForegroundColor Green
-Write-Host "$(Get-Content "${env:ProgramFiles(x86)}\Jenkins\secrets\initialAdminPassword")" -ForegroundColor Green
-
-Write-Host 'Writing README to Desktop; this file contains login information for all C4B services.'
-New-QuickstartReadme
-
-Write-Host 'Cleaning up temporary data'
-Remove-JsonFiles
-
-$Message = 'The CCM, Nexus & Jenkins sites will open in your browser in 10 seconds. Press any key to skip this.'
-$Timeout = New-TimeSpan -Seconds 10
-$Stopwatch = [System.Diagnostics.Stopwatch]::new()
-$Stopwatch.Start()
-Write-Host $Message -NoNewline -ForegroundColor Green
-do {
-    # wait for a key to be available:
-    if ([Console]::KeyAvailable) {
-        # read the key, and consume it so it won't
-        # be echoed to the console:
-        $keyInfo = [Console]::ReadKey($true)
-        Write-Host "`nSkipping the Opening of sites in your browser." -ForegroundColor Green
-        # exit loop
+begin {
+    if($host.name -ne 'ConsoleHost') {
+        Write-Warning "This script cannot be ran from within PowerShell ISE"
+        Write-Warning "Please launch powershell.exe as an administrator, and run this script again"
         break
     }
-    # write a dot and wait a second
-    Write-Host '.' -NoNewline -ForegroundColor Green
-    Start-Sleep -Seconds 1
-}
-while ($Stopwatch.Elapsed -lt $Timeout)
-$Stopwatch.Stop()
-
-if (-not ($keyInfo)) {
-    Write-Host "`nOpening CCM, Nexus & Jenkins sites in your browser." -ForegroundColor Green
-    $Readme = 'file:///C:/Users/Public/Desktop/README.html'
-    $Ccm = "https://${hostname}/Account/Login"
-    $Nexus = "https://${hostname}:8443"
-    $Jenkins = 'http://localhost:8080'
-    try {
-        Start-Process msedge.exe "$Readme","$Ccm", "$Nexus", "$Jenkins"
-    }
-    catch {
-        Start-Process chrome.exe "$Readme","$Ccm", "$Nexus", "$Jenkins"
-    }
 }
 
-$ErrorActionPreference = $DefaultEap
-Stop-Transcript
+
+process {
+    $DefaultEap = $ErrorActionPreference
+    $ErrorActionPreference = 'Stop'
+    Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Start-C4bJenkinsSetup-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
+
+    # Dot-source helper functions
+    . .\scripts\Get-Helpers.ps1
+
+    # Install Jenkins
+    $chocoArgs = @('install', 'jenkins', '-y', "--source='$Source'", '--no-progress',"--version='2.222.4'")
+    & choco @chocoArgs
+
+    choco pin add --name="'jenkins'" --version="'2.222.4'" --reason="'Next version is a breaking change; see online QDE documentation FAQ'"
+
+    Write-Host "Giving Jenkins 30 seconds to complete background setup..." -ForegroundColor Green
+    Start-Sleep -Seconds 30  # Jenkins needs a moment
+
+    # Long winded way to get the scripts for Jenkins jobs into the right place, but easier to mainntain going forward
+    $root = Split-Path -Parent $MyInvocation.MyCommand.Definition
+    $systemRoot = $env:SystemDrive + '\'
+    $JenkinsRoot = Join-Path $root -ChildPath 'jenkins'
+    $jenkinsScripts = Join-Path $JenkinsRoot -ChildPath 'scripts'
+
+    Move-Item $jenkinsScripts $systemRoot -Force
+
+    Stop-Service -Name Jenkins
+    $JenkinsHome = "${env:ProgramFiles(x86)}\Jenkins"
+    $JenkinsConfigPath = Join-Path $JenkinsHome "config.xml"
+    Copy-Item -Path $JenkinsConfigPath -Destination "$($JenkinsConfigPath).old" -Force
+
+    # Ignore "first startup"
+    Write-Host "Disabling Jenkins first-run prompts" -ForegroundColor Green
+    Get-Content -Path "$($JenkinsConfigPath).old" |
+        Where-Object { $_ -notlike "*<installStateName>*" } |
+        Set-Content -Path $JenkinsConfigPath
+
+    Write-Host "Updating Jenkins plugins" -ForegroundColor Green
+    $JenkinsPlugins = @{
+        'cloudbees-folder' = '6.15'
+        'trilead-api' = '1.0.13'
+        'antisamy-markup-formatter' = '2.1'
+        'structs' = '1.23'
+        'workflow-step-api' = '2.23'
+        'token-macro' = '2.13'
+        'build-timeout' = '1.20'
+        'credentials' = '2.5'
+        'plain-credentials' = '1.7'
+        'ssh-credentials' = '1.18.1'
+        'credentials-binding' = '1.24'
+        'scm-api' = '2.6.4'
+        'workflow-api' = '2.46'
+        'timestamper' = '1.13'
+        'caffeine-api' = '2.9.1-23.v51c4e2c879c8'
+        'script-security' = '1.77'
+        'plugin-util-api' = '1.7.1'
+        'font-awesome-api' = '5.15.2-1'
+        'popper-api' = '1.16.1-1'
+        'jquery3-api' = '3.5.1-2'
+        'bootstrap4-api' = '4.6.0-1'
+        'snakeyaml-api' = '1.29.1'
+        'jackson2-api' = '2.12.3'
+        'echarts-api' = '4.9.0-3'
+        'display-url-api' = '2.3.5'
+        'workflow-support' = '3.8'
+        'workflow-job' = '2.41'
+        'checks-api' = '1.5.0'
+        'junit' = '1.51'
+        'matrix-project' = '1.18'
+        'resource-disposer' = '0.16'
+        'ws-cleanup' = '0.39'
+        'ant' = '1.11'
+        'durable-task' = '1.37'
+        'workflow-durable-task-step' = '2.35'
+        'command-launcher' = '1.6'
+        'jdk-tool' = '1.5'
+        'bouncycastle-api' = '2.20'
+        'ace-editor' = '1.1'
+        'workflow-scm-step' = '2.13'
+        'workflow-cps' = '2.92'
+        'apache-httpcomponents-client-4-api' = '4.5.13-1.0'
+        'mailer' = '1.32.1'
+        'workflow-basic-steps' = '2.21'
+        'gradle' = '1.36'
+        'pipeline-milestone-step' = '1.3.2'
+        'pipeline-input-step' = '2.12'
+        'pipeline-stage-step' = '2.5'
+        'pipeline-graph-analysis' = '1.11'
+        'pipeline-rest-api' = '2.19'
+        'handlebars' = '3.0.8'
+        'momentjs' = '1.1.1'
+        'pipeline-stage-view' = '2.19'
+        'pipeline-build-step' = '2.13'
+        'pipeline-model-api' = '1.8.5'
+        'pipeline-model-extensions' = '1.8.5'
+        'jsch' = '0.1.55.2'
+        'git-client' = '3.6.0'
+        'git-server' = '1.9'
+        'workflow-cps-global-lib' = '2.19'
+        'branch-api' = '2.6.2'
+        'workflow-multibranch' = '2.24'
+        'pipeline-stage-tags-metadata' = '1.8.5'
+        'pipeline-model-definition' = '1.8.5'
+        'lockable-resources' = '2.11'
+        'workflow-aggregator' = '2.6'
+        'jjwt-api' = '0.11.2-9.c8b45b8bb173'
+        'okhttp-api' = '3.14.9'
+        'github-api' = '1.123'
+        'git' = '4.6.0'
+        'github' = '1.33.1'
+        'github-branch-source' = '2.9.9'
+        'pipeline-github-lib' = '1.0'
+        'mapdb-api' = '1.0.9.0'
+        'subversion' = '2.14.4'
+        'ssh-slaves' = '1.31.5'
+        'matrix-auth' = '2.6.7'
+        'pam-auth' = '1.6'
+        'ldap' = '1.25'
+        'email-ext' = '2.83'
+        'powershell' = '1.5'
+    }
+
+    foreach ($PluginName in $JenkinsPlugins.Keys) {
+        $PluginUri = 'https://updates.jenkins-ci.org/download/plugins/{0}/{1}/{0}.hpi' -f $PluginName,$JenkinsPlugins[$PluginName]
+        $PluginPath = '{0}/plugins/{1}.hpi' -f $JenkinsHome, $PluginName
+        [System.Net.WebClient]::New().DownloadFile($PluginUri,$PluginPath)
+    }
+
+    #region Job Config
+    Write-Host "Creating Chocolatey Jobs" -ForegroundColor Green
+    Get-ChildItem "$env:SystemDrive\choco-setup\files\jenkins" | Copy-Item -Destination "$JenkinsHome\jobs\" -Recurse
+
+
+    Get-ChildItem -Path "$JenkinsHome\jobs" -Recurse -File -Filter 'config.xml' | ForEach-Object {
+        (Get-Content -Path $_.FullName -Raw) -replace
+            '{{NugetApiKey}}', $NuGetApiKey -replace
+            '{{hostname}}', $HostName |
+            Set-Content -Path $_.FullName
+    }
+    #endregion
+
+    Write-Host "Starting Jenkins service back up" -ForegroundColor Green
+    Start-Service -Name Jenkins
+
+    # Save useful params to JSON
+    $JenkinsJson = @{
+        JenkinsUri = "http://localhost:8080"
+        JenkinsUser = "admin"
+        JenkinsPw = $(Get-Content "${env:ProgramFiles(x86)}\Jenkins\secrets\initialAdminPassword")
+    }
+    $JenkinsJson | ConvertTo-Json | Out-File "$env:SystemDrive\choco-setup\logs\jenkins.json"
+
+    Write-Host 'Jenkins setup complete' -ForegroundColor Green
+    Write-Host 'Login to Jenkins at: http://locahost:8080' -ForegroundColor Green
+    Write-Host 'Initial default Jenkins admin user password:' -ForegroundColor Green
+    Write-Host "$(Get-Content "${env:ProgramFiles(x86)}\Jenkins\secrets\initialAdminPassword")" -ForegroundColor Green
+
+    Write-Host 'Writing README to Desktop; this file contains login information for all C4B services.'
+    New-QuickstartReadme
+
+    Write-Host 'Cleaning up temporary data'
+    Remove-JsonFiles
+
+    $Message = 'The CCM, Nexus & Jenkins sites will open in your browser in 10 seconds. Press any key to skip this.'
+    $Timeout = New-TimeSpan -Seconds 10
+    $Stopwatch = [System.Diagnostics.Stopwatch]::new()
+    $Stopwatch.Start()
+    Write-Host $Message -NoNewline -ForegroundColor Green
+    do {
+        # wait for a key to be available:
+        if ([Console]::KeyAvailable) {
+            # read the key, and consume it so it won't
+            # be echoed to the console:
+            $keyInfo = [Console]::ReadKey($true)
+            Write-Host "`nSkipping the Opening of sites in your browser." -ForegroundColor Green
+            # exit loop
+            break
+        }
+        # write a dot and wait a second
+        Write-Host '.' -NoNewline -ForegroundColor Green
+        Start-Sleep -Seconds 1
+    }
+    while ($Stopwatch.Elapsed -lt $Timeout)
+    $Stopwatch.Stop()
+
+    if (-not ($keyInfo)) {
+        Write-Host "`nOpening CCM, Nexus & Jenkins sites in your browser." -ForegroundColor Green
+        $Readme = 'file:///C:/Users/Public/Desktop/README.html'
+        $Ccm = "https://${hostname}/Account/Login"
+        $Nexus = "https://${hostname}:8443"
+        $Jenkins = 'http://localhost:8080'
+        try {
+            Start-Process msedge.exe "$Readme","$Ccm", "$Nexus", "$Jenkins"
+        }
+        catch {
+            Start-Process chrome.exe "$Readme","$Ccm", "$Nexus", "$Jenkins"
+        }
+    }
+
+    $ErrorActionPreference = $DefaultEap
+    Stop-Transcript
+}

--- a/Start-C4bNexusSetup.ps1
+++ b/Start-C4bNexusSetup.ps1
@@ -21,103 +21,114 @@ param(
     $Browser = 'Edge'
 )
 
-$DefaultEap = $ErrorActionPreference
-$ErrorActionPreference = 'Stop'
-Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Start-C4bNexusSetup-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
-
-# Dot-source helper functions
-. .\scripts\Get-Helpers.ps1
-
-# Install base nexus-repository package
-$chocoArgs = @('install','nexus-repository','-y',"--source='https://chocolatey.org/api/v2'",'--no-progress')
-& choco @chocoArgs
-
-#Build Credential Object, Connect to Nexus
-$securePw = (Get-Content 'C:\programdata\sonatype-work\nexus3\admin.password') | ConvertTo-SecureString -AsPlainText -Force
-$Credential = [System.Management.Automation.PSCredential]::new('admin',$securePw)
-
-Connect-NexusServer -Hostname localhost -Credential $Credential
-
-#Drain default repositories
-Get-NexusRepository | Remove-NexusRepository -Force
-
-#Enable NuGet Auth Realm
-Enable-NexusRealm -Realm 'NuGet API-Key Realm'
-
-#Create Chocolatey repositories
-New-NexusNugetHostedRepository -Name ChocolateyInternal -DeploymentPolicy Allow
-New-NexusNugetHostedRepository -Name ChocolateyTest -DeploymentPolicy Allow
-New-NexusRawHostedRepository -Name choco-install -DeploymentPolicy Allow -ContentDisposition Attachment
-
-#Surface API Key
-$NuGetApiKey = (Get-NexusNuGetApiKey -Credential $Credential).apikey
-
-# Push all packages from previous steps to NuGet repo
-Get-ChildItem -Path "$env:SystemDrive\choco-setup\packages" -Filter *.nupkg |
-    ForEach-Object {
-        choco push $_.FullName --source "$((Get-NexusRepository -Name 'ChocolateyInternal').url)" --apikey $NugetApiKey --force
+begin {
+    if($host.name -ne 'ConsoleHost') {
+        Write-Warning "This script cannot be ran from within PowerShell ISE"
+        Write-Warning "Please launch powershell.exe as an administrator, and run this script again"
+        break
     }
+}
 
-# Add ChooclateyInternal as a source repository
-choco source add -n 'ChocolateyInternal' -s "$((Get-NexusRepository -Name 'ChocolateyInternal').url)/" --priority 1
 
-# Install a non-IE browser for browsing the Nexus web portal.
-# Edge sometimes fails install due to latest Windows Updates not being installed.
-# In that scenario, Google Chrome is installed instead.
-$null = choco install microsoft-edge -y --source="'https://community.chocolatey.org/api/v2/'"
-if ($LASTEXITCODE -eq 0) {
-    if (Test-Path 'HKLM:\SOFTWARE\Microsoft\Edge') {
-        $RegArgs = @{
-        Path = 'HKLM:\SOFTWARE\Microsoft\Edge\'
-        Name = 'HideFirstRunExperience'
-        Type = 'Dword'
-        Value = 1
-        Force = $true
+process {
+    $DefaultEap = $ErrorActionPreference
+    $ErrorActionPreference = 'Stop'
+    Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Start-C4bNexusSetup-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
+
+    # Dot-source helper functions
+    . .\scripts\Get-Helpers.ps1
+
+    # Install base nexus-repository package
+    $chocoArgs = @('install','nexus-repository','-y',"--source='https://chocolatey.org/api/v2'",'--no-progress')
+    & choco @chocoArgs
+
+    #Build Credential Object, Connect to Nexus
+    $securePw = (Get-Content 'C:\programdata\sonatype-work\nexus3\admin.password') | ConvertTo-SecureString -AsPlainText -Force
+    $Credential = [System.Management.Automation.PSCredential]::new('admin',$securePw)
+
+    Connect-NexusServer -Hostname localhost -Credential $Credential
+
+    #Drain default repositories
+    Get-NexusRepository | Remove-NexusRepository -Force
+
+    #Enable NuGet Auth Realm
+    Enable-NexusRealm -Realm 'NuGet API-Key Realm'
+
+    #Create Chocolatey repositories
+    New-NexusNugetHostedRepository -Name ChocolateyInternal -DeploymentPolicy Allow
+    New-NexusNugetHostedRepository -Name ChocolateyTest -DeploymentPolicy Allow
+    New-NexusRawHostedRepository -Name choco-install -DeploymentPolicy Allow -ContentDisposition Attachment
+
+    #Surface API Key
+    $NuGetApiKey = (Get-NexusNuGetApiKey -Credential $Credential).apikey
+
+    # Push all packages from previous steps to NuGet repo
+    Get-ChildItem -Path "$env:SystemDrive\choco-setup\packages" -Filter *.nupkg |
+        ForEach-Object {
+            choco push $_.FullName --source "$((Get-NexusRepository -Name 'ChocolateyInternal').url)" --apikey $NugetApiKey --force
         }
-        Set-ItemProperty @RegArgs
+
+    # Add ChooclateyInternal as a source repository
+    choco source add -n 'ChocolateyInternal' -s "$((Get-NexusRepository -Name 'ChocolateyInternal').url)/" --priority 1
+
+    # Install a non-IE browser for browsing the Nexus web portal.
+    # Edge sometimes fails install due to latest Windows Updates not being installed.
+    # In that scenario, Google Chrome is installed instead.
+    $null = choco install microsoft-edge -y --source="'https://community.chocolatey.org/api/v2/'"
+    if ($LASTEXITCODE -eq 0) {
+        if (Test-Path 'HKLM:\SOFTWARE\Microsoft\Edge') {
+            $RegArgs = @{
+            Path = 'HKLM:\SOFTWARE\Microsoft\Edge\'
+            Name = 'HideFirstRunExperience'
+            Type = 'Dword'
+            Value = 1
+            Force = $true
+            }
+            Set-ItemProperty @RegArgs
+        }
     }
-}
-else {
-    Write-Warning "Microsoft Edge install was not succesful."
-    Write-Host "Installing Google Chrome as an alternative."
-    choco install googlechrome -y --source="'https://community.chocolatey.org/api/v2/'"
-}
+    else {
+        Write-Warning "Microsoft Edge install was not succesful."
+        Write-Host "Installing Google Chrome as an alternative."
+        choco install googlechrome -y --source="'https://community.chocolatey.org/api/v2/'"
+    }
 
-# Add Nexus port 8081 access via firewall
-$FwRuleParams = @{
-    DisplayName    = 'Nexus Repository access on TCP 8081'
-    Direction = 'Inbound'
-    LocalPort = 8081
-    Protocol = 'TCP'
-    Action = 'Allow'
-}
-$null = New-NetFirewallRule @FwRuleParams
+    # Add Nexus port 8081 access via firewall
+    $FwRuleParams = @{
+        DisplayName    = 'Nexus Repository access on TCP 8081'
+        Direction = 'Inbound'
+        LocalPort = 8081
+        Protocol = 'TCP'
+        Action = 'Allow'
+    }
+    $null = New-NetFirewallRule @FwRuleParams
 
-# Save useful params to JSON
-$NexusJson = @{
-    NexusUri = "http://localhost:8081"
-    NexusUser = "admin"
-    NexusPw = "$($Credential.GetNetworkCredential().Password)"
-    NexusRepo = "$((Get-NexusRepository -Name 'ChocolateyInternal').url)/"
-    NuGetApiKey = $NugetApiKey
-}
-$NexusJson | ConvertTo-Json | Out-File "$env:SystemDrive\choco-setup\logs\nexus.json"
+    # Save useful params to JSON
+    $NexusJson = @{
+        NexusUri = "http://localhost:8081"
+        NexusUser = "admin"
+        NexusPw = "$($Credential.GetNetworkCredential().Password)"
+        NexusRepo = "$((Get-NexusRepository -Name 'ChocolateyInternal').url)/"
+        NuGetApiKey = $NugetApiKey
+    }
+    $NexusJson | ConvertTo-Json | Out-File "$env:SystemDrive\choco-setup\logs\nexus.json"
 
-$finishOutput = @"
-##############################################################
+    $finishOutput = @"
+    ##############################################################
 
-Nexus Repository Setup Completed
-Please login to the following URL to complete admin account setup:
+    Nexus Repository Setup Completed
+    Please login to the following URL to complete admin account setup:
 
-Server Url: 'http://localhost:8081' (this will change once you add a certificate)
-Chocolatey Repo: "$((Get-NexusRepository -Name 'ChocolateyInternal').url)/"
-NuGet ApiKey: $NugetApiKey
-Nexus 'admin' user password: $($Credential.GetNetworkCredential().Password)
+    Server Url: 'http://localhost:8081' (this will change once you add a certificate)
+    Chocolatey Repo: "$((Get-NexusRepository -Name 'ChocolateyInternal').url)/"
+    NuGet ApiKey: $NugetApiKey
+    Nexus 'admin' user password: $($Credential.GetNetworkCredential().Password)
 
-##############################################################
+    ##############################################################
 "@
 
-Write-Host "$finishOutput" -ForegroundColor Green
+    Write-Host "$finishOutput" -ForegroundColor Green
 
-$ErrorActionPreference = $DefaultEap
-Stop-Transcript
+    $ErrorActionPreference = $DefaultEap
+    Stop-Transcript
+}

--- a/Start-C4bSetup.ps1
+++ b/Start-C4bSetup.ps1
@@ -34,55 +34,26 @@ param(
     $Thumbprint
 )
 
-$DefaultEap = $ErrorActionPreference
-$ErrorActionPreference = 'Stop'
-Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Start-C4bSetup-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
-
-# If variables for Unattend are not defined, prompt for them.
-if ($Unattend) {
-    if (-not($LicenseFile)) {
-        # Have user select license, install license, and licensed extension
-        $Wshell = New-Object -ComObject Wscript.Shell
-        $null = $Wshell.Popup('You have selected Unattended Mode, and will need to provide the license file location, as well as database credentials for CCM. Please select your Chocolatey License in the next file dialog.')
-        $null = [System.Reflection.Assembly]::LoadWithPartialName("System.windows.forms")
-        $OpenFileDialog = New-Object System.Windows.Forms.OpenFileDialog
-        $OpenFileDialog.initialDirectory = "$env:USERPROFILE\Downloads"
-        $OpenFileDialog.filter = 'All Files (*.*)| *.*'
-        $null = $OpenFileDialog.ShowDialog()
-        $LicenseFile = $OpenFileDialog.filename
+begin {
+    if($host.name -ne 'ConsoleHost') {
+        Write-Warning "This script cannot be ran from within PowerShell ISE"
+        Write-Warning "Please launch powershell.exe as an administrator, and run this script again"
+        break
     }
-    if (-not($DatabaseCredential)) {
-        $Wshell = New-Object -ComObject Wscript.Shell
-        $null = $Wshell.Popup('You will now create a credential for the ChocolateyManagement DB user, to be used by CCM (document this somewhere).')
-        $DatabaseCredential = (Get-Credential -Username ChocoUser -Message 'Create a credential for the ChocolateyManagement DB user')
-    }
-
 }
 
-function Install-ChocoLicensed {
+process {
 
-    [CmdletBinding()]
-    Param(
-        [Parameter(Position = 0)]
-        [String]
-        $LicenseFile
-    )
+    $DefaultEap = $ErrorActionPreference
+    $ErrorActionPreference = 'Stop'
+    Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Start-C4bSetup-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
 
-    process {
-        # Check if choco is installed; if not, install it
-        if (-not(Test-Path "$env:ProgramData\chocolatey\choco.exe")) {
-            Write-Host "Chocolatey is not installed. Installing now." -ForegroundColor Green
-            Invoke-Expression -Command ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
-            refreshenv
-        }
-        # Create license directory if not present
-        if (-not(Test-Path "$env:ProgramData\chocolatey\license")) {
-            $null = New-Item "$env:ProgramData\chocolatey\license" -ItemType Directory -Force
-        }
+    # If variables for Unattend are not defined, prompt for them.
+    if ($Unattend) {
         if (-not($LicenseFile)) {
             # Have user select license, install license, and licensed extension
             $Wshell = New-Object -ComObject Wscript.Shell
-            $null = $Wshell.Popup('Please select your Chocolatey License File in the next file dialog.')
+            $null = $Wshell.Popup('You have selected Unattended Mode, and will need to provide the license file location, as well as database credentials for CCM. Please select your Chocolatey License in the next file dialog.')
             $null = [System.Reflection.Assembly]::LoadWithPartialName("System.windows.forms")
             $OpenFileDialog = New-Object System.Windows.Forms.OpenFileDialog
             $OpenFileDialog.initialDirectory = "$env:USERPROFILE\Downloads"
@@ -90,90 +61,130 @@ function Install-ChocoLicensed {
             $null = $OpenFileDialog.ShowDialog()
             $LicenseFile = $OpenFileDialog.filename
         }
-        # Validate license expiry
-        [xml]$LicenseXml = Get-Content -Path $LicenseFile
-        $LicenseExpiration = [datetimeoffset]::Parse("$($LicenseXml.SelectSingleNode('/license').expiration) +0")
-        if ($LicenseExpiration -lt [datetimeoffset]::UtcNow) {
-            Write-Warning "Your Chocolatey License file has EXPIRED, or is otherwise INVALID."
-            Write-Warning "Please contact your Chocolatey Sales representative for assistance at sales@chocolatey.io ."
-            Write-Warning "This script will now exit, as you require a valid license to proceed."
-            throw "License is expired as of $($LicenseExpiration.ToString()). Please use an up to date license."
+        if (-not($DatabaseCredential)) {
+            $Wshell = New-Object -ComObject Wscript.Shell
+            $null = $Wshell.Popup('You will now create a credential for the ChocolateyManagement DB user, to be used by CCM (document this somewhere).')
+            $DatabaseCredential = (Get-Credential -Username ChocoUser -Message 'Create a credential for the ChocolateyManagement DB user')
         }
-        else {
-            Write-Host "Installing your valid Chocolatey License." -ForegroundColor Green
-            Copy-Item $LicenseFile -Destination C:\ProgramData\chocolatey\license\chocolatey.license.xml
-            Write-Host "Installing the Chocolatey Licensed Extension." -ForegroundColor Green
-            $null = choco install chocolatey.extension -y
+
+    }
+
+    function Install-ChocoLicensed {
+
+        [CmdletBinding()]
+        Param(
+            [Parameter(Position = 0)]
+            [String]
+            $LicenseFile
+        )
+
+        process {
+            # Check if choco is installed; if not, install it
+            if (-not(Test-Path "$env:ProgramData\chocolatey\choco.exe")) {
+                Write-Host "Chocolatey is not installed. Installing now." -ForegroundColor Green
+                Invoke-Expression -Command ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+                refreshenv
+            }
+            # Create license directory if not present
+            if (-not(Test-Path "$env:ProgramData\chocolatey\license")) {
+                $null = New-Item "$env:ProgramData\chocolatey\license" -ItemType Directory -Force
+            }
+            if (-not($LicenseFile)) {
+                # Have user select license, install license, and licensed extension
+                $Wshell = New-Object -ComObject Wscript.Shell
+                $null = $Wshell.Popup('Please select your Chocolatey License File in the next file dialog.')
+                $null = [System.Reflection.Assembly]::LoadWithPartialName("System.windows.forms")
+                $OpenFileDialog = New-Object System.Windows.Forms.OpenFileDialog
+                $OpenFileDialog.initialDirectory = "$env:USERPROFILE\Downloads"
+                $OpenFileDialog.filter = 'All Files (*.*)| *.*'
+                $null = $OpenFileDialog.ShowDialog()
+                $LicenseFile = $OpenFileDialog.filename
+            }
+            # Validate license expiry
+            [xml]$LicenseXml = Get-Content -Path $LicenseFile
+            $LicenseExpiration = [datetimeoffset]::Parse("$($LicenseXml.SelectSingleNode('/license').expiration) +0")
+            if ($LicenseExpiration -lt [datetimeoffset]::UtcNow) {
+                Write-Warning "Your Chocolatey License file has EXPIRED, or is otherwise INVALID."
+                Write-Warning "Please contact your Chocolatey Sales representative for assistance at sales@chocolatey.io ."
+                Write-Warning "This script will now exit, as you require a valid license to proceed."
+                throw "License is expired as of $($LicenseExpiration.ToString()). Please use an up to date license."
+            }
+            else {
+                Write-Host "Installing your valid Chocolatey License." -ForegroundColor Green
+                Copy-Item $LicenseFile -Destination C:\ProgramData\chocolatey\license\chocolatey.license.xml
+                Write-Host "Installing the Chocolatey Licensed Extension." -ForegroundColor Green
+                $null = choco install chocolatey.extension -y
+            }
         }
     }
-}
-if (-not($LicenseFile)) {
-    Install-ChocoLicensed
-}
-else {
-    Install-ChocoLicensed -LicenseFile $LicenseFile
-}
-
-# Setup initial choco-setup directories
-Write-Host "Setting up initial directories in"$env:SystemDrive\choco-setup"" -ForegroundColor Green
-$ChocoPath = "$env:SystemDrive\choco-setup"
-$FilesDir = "$ChocoPath\files"
-$PkgsDir = "$ChocoPath\packages"
-$TempDir = "$ChocoPath\temp"
-@($ChocoPath, $FilesDir, $PkgsDir, $TempDir) |
-Foreach-Object {
-    $null = New-Item -Path $_ -ItemType Directory -Force
-}
-
-# Download and extract C4B setup files from repo
-$QsRepo = "https://github.com/chocolatey/choco-quickstart-scripts/archive/main.zip"
-Invoke-WebRequest -Uri $QsRepo -UseBasicParsing -OutFile "$TempDir\main.zip"
-Expand-Archive "$TempDir\main.zip" $TempDir
-Copy-Item "$TempDir\choco-quickstart-scripts-main\*" $FilesDir -Recurse
-Remove-Item "$TempDir" -Recurse -Force
-
-# Convert license to a "choco-license" package, and install it locally to test
-Write-Host "Creating a "chocolatey-license" package, and testing install." -ForegroundColor Green
-Set-Location $FilesDir
-.\scripts\Create-ChocoLicensePkg.ps1
-Remove-Item "$env:SystemDrive\choco-setup\packaging" -Recurse -Force
-
-# Downloading all CCM setup packages below
-Write-Host "Downloading nupkg files to C:\choco-setup\packages." -ForegroundColor Green
-Write-Host "This will take some time. Feel free to get a tea or coffee." -ForegroundColor Green
-Start-Sleep -Seconds 5
-$PkgsDir = "$env:SystemDrive\choco-setup\packages"
-$Ccr = "'https://community.chocolatey.org/api/v2/'"
-
-# Download Chocolatey community related items, no internalization necessary
-@('chocolatey', 'chocolateygui') |
-Foreach-Object {
-    choco download $_ --no-progress --force --source $Ccr --output-directory $PkgsDir
-}
-
-# Internalize dotnet4.5.2 for ChocolateyGUI (just in case endpoints need it)
-choco download dotnet4.5.2 --no-progress --force --internalize --internalize-all-urls --append-use-original-location --source $Ccr  --output-directory $PkgsDir
-
-# Download Licensed Packages
-## DO NOT RUN WITH `--internalize` and `--internalize-all-urls` - see https://github.com/chocolatey/chocolatey-licensed-issues/issues/155
-@('chocolatey-agent', 'chocolatey.extension', 'chocolateygui.extension', 'chocolatey-management-database', 'chocolatey-management-service', 'chocolatey-management-web') |
-Foreach-Object {
-    choco download $_ --force --no-progress --source="'https://licensedpackages.chocolatey.org/api/v2/'" --ignore-dependencies --output-directory $PkgsDir
-}
-
-# Kick off unattended running of remainder setup scripts.
-if ($Unattend) {
-    Set-Location "$env:SystemDrive\choco-setup\files"
-    .\Start-C4BNexusSetup.ps1
-    .\Start-C4bCcmSetup.ps1 -DatabaseCredential $DatabaseCredential
-    if ($Thumbprint) {
-        .\Set-SslSecurity.ps1 -Thumbprint $Thumbprint
+    if (-not($LicenseFile)) {
+        Install-ChocoLicensed
     }
     else {
-        .\Set-SslSecurity.ps1
+        Install-ChocoLicensed -LicenseFile $LicenseFile
     }
-    .\Start-C4bJenkinsSetup.ps1
-}
 
-$ErrorActionPreference = $DefaultEap
-Stop-Transcript
+    # Setup initial choco-setup directories
+    Write-Host "Setting up initial directories in"$env:SystemDrive\choco-setup"" -ForegroundColor Green
+    $ChocoPath = "$env:SystemDrive\choco-setup"
+    $FilesDir = "$ChocoPath\files"
+    $PkgsDir = "$ChocoPath\packages"
+    $TempDir = "$ChocoPath\temp"
+    @($ChocoPath, $FilesDir, $PkgsDir, $TempDir) |
+    Foreach-Object {
+        $null = New-Item -Path $_ -ItemType Directory -Force
+    }
+
+    # Download and extract C4B setup files from repo
+    $QsRepo = "https://github.com/chocolatey/choco-quickstart-scripts/archive/main.zip"
+    Invoke-WebRequest -Uri $QsRepo -UseBasicParsing -OutFile "$TempDir\main.zip"
+    Expand-Archive "$TempDir\main.zip" $TempDir
+    Copy-Item "$TempDir\choco-quickstart-scripts-main\*" $FilesDir -Recurse
+    Remove-Item "$TempDir" -Recurse -Force
+
+    # Convert license to a "choco-license" package, and install it locally to test
+    Write-Host "Creating a "chocolatey-license" package, and testing install." -ForegroundColor Green
+    Set-Location $FilesDir
+    .\scripts\Create-ChocoLicensePkg.ps1
+    Remove-Item "$env:SystemDrive\choco-setup\packaging" -Recurse -Force
+
+    # Downloading all CCM setup packages below
+    Write-Host "Downloading nupkg files to C:\choco-setup\packages." -ForegroundColor Green
+    Write-Host "This will take some time. Feel free to get a tea or coffee." -ForegroundColor Green
+    Start-Sleep -Seconds 5
+    $PkgsDir = "$env:SystemDrive\choco-setup\packages"
+    $Ccr = "'https://community.chocolatey.org/api/v2/'"
+
+    # Download Chocolatey community related items, no internalization necessary
+    @('chocolatey', 'chocolateygui') |
+    Foreach-Object {
+        choco download $_ --no-progress --force --source $Ccr --output-directory $PkgsDir
+    }
+
+    # Internalize dotnet4.5.2 for ChocolateyGUI (just in case endpoints need it)
+    choco download dotnet4.5.2 --no-progress --force --internalize --internalize-all-urls --append-use-original-location --source $Ccr  --output-directory $PkgsDir
+
+    # Download Licensed Packages
+    ## DO NOT RUN WITH `--internalize` and `--internalize-all-urls` - see https://github.com/chocolatey/chocolatey-licensed-issues/issues/155
+    @('chocolatey-agent', 'chocolatey.extension', 'chocolateygui.extension', 'chocolatey-management-database', 'chocolatey-management-service', 'chocolatey-management-web') |
+    Foreach-Object {
+        choco download $_ --force --no-progress --source="'https://licensedpackages.chocolatey.org/api/v2/'" --ignore-dependencies --output-directory $PkgsDir
+    }
+
+    # Kick off unattended running of remainder setup scripts.
+    if ($Unattend) {
+        Set-Location "$env:SystemDrive\choco-setup\files"
+        .\Start-C4BNexusSetup.ps1
+        .\Start-C4bCcmSetup.ps1 -DatabaseCredential $DatabaseCredential
+        if ($Thumbprint) {
+            .\Set-SslSecurity.ps1 -Thumbprint $Thumbprint
+        }
+        else {
+            .\Set-SslSecurity.ps1
+        }
+        .\Start-C4bJenkinsSetup.ps1
+    }
+
+    $ErrorActionPreference = $DefaultEap
+    Stop-Transcript
+}


### PR DESCRIPTION
## Description Of Changes

The changes in this Pull Request prevent the execution of the Quickstart Guide from within PowerShell ISE.

## Motivation and Context

To eliminate support requires where an end user attempts to run the Guide in ISE and sees failures, this change puts up guardrails to prevent them from doing so.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [x] PowerShell code changes.

## Related Issue

Fixes #90 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.


