### PR TITLE
Remove 'QDE' References

### DIFF
--- a/Set-SslSecurity.ps1
+++ b/Set-SslSecurity.ps1
@@ -42,7 +42,7 @@ param(
     [switch]
     $Hardened,
 
-    # The QDE hostname for which to generate a new self-signed certificate.
+    # The C4B server hostname for which to generate a new self-signed certificate.
     # Ignored/unused if a certificate thumbprint or subject is supplied.
     [Parameter()]
     [string]

--- a/scripts/ClientSetup.ps1
+++ b/scripts/ClientSetup.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-Completes client setup for a client machine to communicate with QDE.
+Completes client setup for a client machine to communicate with the C4B Server.
 #>
 [CmdletBinding(DefaultParameterSetName = 'Default')]
 param(
@@ -13,7 +13,7 @@ param(
 
     # The credential necessary to access the internal Nexus repository. This can
     # be ignored if Anonymous authentication is enabled.
-    # This parameter will be necessary if your QDE setup is web-enabled.
+    # This parameter will be necessary if your C4B server is web-enabled.
     [Parameter()]
     [pscredential]
     $Credential,


### PR DESCRIPTION
## Description Of Changes

Removes references to 'QDE' across all scripts in the guide.

## Motivation and Context
We aren't building QDE anymore, so references to it were outdated and erroneous.

## Testing


## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #108 

## Change Checklist

* [ ] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
