### PR TITLE
Get rid of choco pin and version install declaration for Jenkins

### DIFF
--- a/Start-C4bJenkinsSetup.ps1
+++ b/Start-C4bJenkinsSetup.ps1
@@ -5,7 +5,6 @@ C4B Quick-Start Guide Jenkins setup script
 .DESCRIPTION
 - Performs the following Jenkins setup
     - Install of Jenkins package
-    - Pin to version 2.222.4
     - Silent upgrade of Jenkins plugins
     - Creation of Chocolatey-specific jobs from template files
     - Disable of first-run prompts
@@ -38,10 +37,8 @@ process {
     . .\scripts\Get-Helpers.ps1
 
     # Install Jenkins
-    $chocoArgs = @('install', 'jenkins', '-y', "--source='$Source'", '--no-progress',"--version='2.222.4'")
+    $chocoArgs = @('install', 'jenkins', '-y', "--source='$Source'", '--no-progress')
     & choco @chocoArgs
-
-    choco pin add --name="'jenkins'" --version="'2.222.4'" --reason="'Next version is a breaking change; see online QDE documentation FAQ'"
 
     Write-Host "Giving Jenkins 30 seconds to complete background setup..." -ForegroundColor Green
     Start-Sleep -Seconds 30  # Jenkins needs a moment


### PR DESCRIPTION
## Description Of Changes
- Git rid of choco pin for jenkins package.
- Remove --version part of install command command for jenkins package
- Update script description to remove pinning on jenkins package.

## Motivation and Context
Since their currently isn't a newer version available on the CCR. Their is no risk of a customer running `choco upgrade all` and breaking their system. 

## Testing
Non-breaking change

## Change Types Made
* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [X] PowerShell code changes.

## Related Issue
[Docs PR](https://github.com/chocolatey/docs/pull/316) has already been merged

Fixes #94 

## Change Checklist

* [X] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
