### PR TITLE
Change Server Salt References to Service Salt

### DIFF
--- a/Set-SslSecurity.ps1
+++ b/Set-SslSecurity.ps1
@@ -241,7 +241,7 @@ process {
 `$params = @{
     Credential      = `$Credential
     ClientSalt      = `$ClientCommunicationSalt
-    ServerSalt      = `$ServiceCommunicationSalt
+    ServiceSalt      = `$ServiceCommunicationSalt
     InternetEnabled = `$true
     RepositoryUrl   = `$RepositoryUrl
 }

--- a/scripts/ClientSetup.ps1
+++ b/scripts/ClientSetup.ps1
@@ -45,11 +45,11 @@ param(
     [string]
     $ClientSalt,
 
-    # Server salt value used to populate the centralManagementServerCommunicationSaltAdditivePassword
+    # Server salt value used to populate the centralManagementServiceCommunicationSaltAdditivePassword
     # value in the Chocolatey config file
     [Parameter()]
     [string]
-    $ServerSalt,
+    $ServiceSalt,
 
     [Parameter()]
     [Switch]
@@ -121,8 +121,8 @@ choco config set CentralManagementServiceUrl "https://${hostName}:24020/Chocolat
 if ($ClientSalt) {
     choco config set centralManagementClientCommunicationSaltAdditivePassword $ClientSalt
 }
-if ($ServerSalt) {
-    choco config set centralManagementServiceCommunicationSaltAdditivePassword $ServerSalt
+if ($ServiceSalt) {
+    choco config set centralManagementServiceCommunicationSaltAdditivePassword $ServiceSalt
 }
 choco feature enable --name="'useChocolateyCentralManagement'"
 choco feature enable --name="'useChocolateyCentralManagementDeployments'"


### PR DESCRIPTION
## Description Of Changes
- Changed the name of the Variable being set in Set-SslSecurity.ps1 from `ServerSalt` to `Service Salt` so the Register-C4bEndpoint.ps1 script gets generated with the correct parameter name.
- Changed `$ServerSalt` variable in ClientSetup.ps1 script to be `$ServiceSalt` so it matches the name of the config setting it applies to more accurately.
- Also made one note change in ClientSetup.ps1 to also reflect correct config setting being set. 

## Motivation and Context
Made sense to change all the Server Salt references to Service salt since the actual config setting this deals with is named `centralManagementServiceCommunicationSaltAdditivePassword` and not server. 

## Testing


## Change Types Made

* [X] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [X] PowerShell code changes.

## Related Issue

Fixes #114 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
