### PR TITLE
(#119) Fix outdated CCR link

### DIFF
--- a/jenkins/Update test repository from Chocolatey Community Repository/config.xml
+++ b/jenkins/Update test repository from Chocolatey Community Repository/config.xml
@@ -15,7 +15,7 @@
         <hudson.model.StringParameterDefinition>
           <name>P_REMOTE_REPO_URL</name>
           <description>Remote repository containing updated package versions.</description>
-          <defaultValue>https://chocolatey.org/api/v2</defaultValue>
+          <defaultValue>https://community.chocolatey.org/api/v2</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.PasswordParameterDefinition>

--- a/jenkins/scripts/Invoke-ChocolateyInternalizer.ps1
+++ b/jenkins/scripts/Invoke-ChocolateyInternalizer.ps1
@@ -31,7 +31,7 @@ param(
     # The remote repo to check against. Defaults to https://chocolatey.org/api/v2
     [Parameter(Position = 2)]
     [string]
-    $RemoteRepo = 'https://chocolatey.org/api/v2'
+    $RemoteRepo = 'https://community.chocolatey.org/api/v2'
 )
 begin {
     if (!(Test-Path "$env:ChocolateyInstall\license")) {


### PR DESCRIPTION
## Description Of Changes
Update Chocolatey Community Repository(CCR) URL definiton in Jenkins.

## Motivation and Context
Keep consistent with current URL to the CCR.

## Testing
Deployed QSG using updated scripts.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [X] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #119 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
