### PR TITLE
(GH-123) Update to current CCR URI

### DIFF
--- a/Start-C4bJenkinsSetup.ps1
+++ b/Start-C4bJenkinsSetup.ps1
@@ -14,7 +14,7 @@ param(
     # Hostname of your C4B Server
     [string]$HostName = $(Get-Content "$env:SystemDrive\choco-setup\logs\ssl.json" | ConvertFrom-Json).CertSubject,
     # Repo where you're installing Jenkins from, usually CCR
-    [string]$Source = 'https://chocolatey.org/api/v2/',
+    [string]$Source = 'https://community.chocolatey.org/api/v2/',
     # API key of your Nexus repo, for Chocolatey Jenkins jobs to use
     [string]$NuGetApiKey = $(Get-Content "$env:SystemDrive\choco-setup\logs\nexus.json" | ConvertFrom-Json).NuGetApiKey
 )

--- a/Start-C4bNexusSetup.ps1
+++ b/Start-C4bNexusSetup.ps1
@@ -39,7 +39,7 @@ process {
     . .\scripts\Get-Helpers.ps1
 
     # Install base nexus-repository package
-    $chocoArgs = @('install','nexus-repository','-y',"--source='https://chocolatey.org/api/v2'",'--no-progress')
+    $chocoArgs = @('install','nexus-repository','-y',"--source='https://community.chocolatey.org/api/v2'",'--no-progress')
     & choco @chocoArgs
 
     #Build Credential Object, Connect to Nexus

--- a/jenkins/scripts/Invoke-ChocolateyInternalizer.ps1
+++ b/jenkins/scripts/Invoke-ChocolateyInternalizer.ps1
@@ -28,7 +28,7 @@ param(
     [string]
     $NexusApiKey,
 
-    # The remote repo to check against. Defaults to https://chocolatey.org/api/v2
+    # The remote repo to check against. Defaults to https://community.chocolatey.org/api/v2
     [Parameter(Position = 2)]
     [string]
     $RemoteRepo = 'https://community.chocolatey.org/api/v2'


### PR DESCRIPTION
## Description Of Changes

This PR changes the last few references to the Chocolatey Community Repository (CCR) at `https://chocolatey.org/api/v2` to the current `https://community.chocolatey.org/api/v2`

## Motivation and Context

Having the correct URI points clients more directly to the CCR, and saves them having to go through a redirect.

## Testing

I've run the snippets in isolation that are directly affected by this change.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [x] PowerShell code changes.

## Related Issue

Fixes #124

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
