### PR TITLE
(#126) Copy-Item scripts instead of Move-Item

### DIFF
--- a/Start-C4bJenkinsSetup.ps1
+++ b/Start-C4bJenkinsSetup.ps1
@@ -49,7 +49,7 @@ process {
     $JenkinsRoot = Join-Path $root -ChildPath 'jenkins'
     $jenkinsScripts = Join-Path $JenkinsRoot -ChildPath 'scripts'
 
-    Move-Item $jenkinsScripts $systemRoot -Force
+    Copy-Item $jenkinsScripts $systemRoot -Force
 
     Stop-Service -Name Jenkins
     $JenkinsHome = "${env:ProgramFiles(x86)}\Jenkins"


### PR DESCRIPTION
## Description Of Changes
Change Move-Item of Jenkins scripts to Copy-Item
## Motivation and Context
Makes the script more idempotent in case the Jenkins install fails and the files are moved but the script must be run again for say a timeout issue. 

## Testing
Tested on fresh QSG install

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [X] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [X] PowerShell code changes.

## Related Issue

Fixes #126 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
