### PR TITLE
Install Nexus with localhost instead of being clever

### DIFF
--- a/Start-C4bNexusSetup.ps1
+++ b/Start-C4bNexusSetup.ps1
@@ -39,7 +39,7 @@ process {
     . .\scripts\Get-Helpers.ps1
 
     # Install base nexus-repository package
-    $chocoArgs = @('install','nexus-repository','-y',"--source='https://community.chocolatey.org/api/v2'",'--no-progress')
+    $chocoArgs = @('install','nexus-repository','-y',"--source='https://community.chocolatey.org/api/v2'",'--no-progress',"--package-parameters='/Fqdn:localhost'")
     & choco @chocoArgs
 
     #Build Credential Object, Connect to Nexus


### PR DESCRIPTION


## Description Of Changes

Force nexus to use `locahost` on installation for verification.

## Motivation and Context

We see a fair few errors where DNS differences cause the pacakge to fail
for really no reason, things worked, just picked the wrong hostname to verify
Using localhost we will _always_ get it right, and this mirrors what we do
in the Azure Marketplace image

## Testing

Replicated Azure Marketplace method, which is fully vetted.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [x] PowerShell code changes.

## Related Issue

Fixes #129 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

