### PR TITLE
(#143) Add Recurse to Scripts Copy

### DIFF
--- a/Start-C4bJenkinsSetup.ps1
+++ b/Start-C4bJenkinsSetup.ps1
@@ -49,7 +49,7 @@ process {
     $JenkinsRoot = Join-Path $root -ChildPath 'jenkins'
     $jenkinsScripts = Join-Path $JenkinsRoot -ChildPath 'scripts'
 
-    Copy-Item $jenkinsScripts $systemRoot -Force
+    Copy-Item $jenkinsScripts $systemRoot -Recurse -Force
 
     Stop-Service -Name Jenkins
     $JenkinsHome = "${env:ProgramFiles(x86)}\Jenkins"


### PR DESCRIPTION
## Description Of Changes
Add -Recurse to copy of Jenkins scripts

## Motivation and Context
Scripts were not copying over without this.

## Testing
1. Ran local edit of script to verify on new QSG install.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [X] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [X] PowerShell code changes.

## Related Issue

Fixes #143 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

