### PR TITLE
Fix variable name for test directory so it gets created correctly

### DIFF
--- a/Start-C4bSetup.ps1
+++ b/Start-C4bSetup.ps1
@@ -131,7 +131,7 @@ process {
     $PkgsDir = "$ChocoPath\packages"
     $TempDir = "$ChocoPath\temp"
     $TestDir = "$ChocoPath\tests"
-    @($ChocoPath, $FilesDir, $PkgsDir, $TempDir,$Test) |
+    @($ChocoPath, $FilesDir, $PkgsDir, $TempDir,$TestDir) |
     Foreach-Object {
         $null = New-Item -Path $_ -ItemType Directory -Force
     }


### PR DESCRIPTION

## Description Of Changes

Fixed variable name for Tests directory so it gets created and doesn't throw a null reference exception

## Motivation and Context
We gotta have the tests directory

## Testing
Validated the change manually running step 1 on a clean box with the fix. It worked.

## Change Types Made

* [ x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #148 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

