### PR TITLE
Adjust Pester test file location

### DIFF
--- a/Start-C4bVerification.ps1
+++ b/Start-C4bVerification.ps1
@@ -15,7 +15,7 @@ process {
     $chocoArgs = @('install', 'pester', '-y', '--source="https://community.chocolatey.org/api/v2/"')
     & choco @chocoArgs
 
-    $files = (Get-ChildItem C:\choco-setup\tests\ -Recurse -Filter *.ps1).Fullname
+    $files = (Get-ChildItem C:\choco-setup\files\tests\ -Recurse -Filter *.ps1).Fullname
     Write-Host "Configuring Pester to complete verification tests"
     $containers = $files | Foreach-Object { New-PesterContainer -Path $_ -Data @{ Fqdn = $Fqdn } }
     $configuration = [PesterConfiguration]@{


### PR DESCRIPTION

## Description Of Changes

Corrects the path to the Pester tests for verification.

## Motivation and Context

If we are to run tests, we should point Pester to the tests.

## Testing

Manual verification on a _new_ VM.

## Change Types Made

* [ x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #149 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
