### PR TITLE
(#99) Be smarter with Subject matching

### DIFF
--- a/Set-SslSecurity.ps1
+++ b/Set-SslSecurity.ps1
@@ -76,7 +76,9 @@ process {
     }
 
     if (-not $CertificateDnsName) {
-        $SubjectWithoutCn = $Certificate.Subject -replace 'CN=', ''
+        $matcher = 'CN\s?=\s?[^,\s]+'
+        $null = $Certificate.Subject -match $matcher
+        $SubjectWithoutCn = $matches[0] -replace 'CN=', ''
     } 
     else {
         $SubjectWithoutCn = $CertificateDnsName


### PR DESCRIPTION
## Description Of Changes

Use Regex to better match the CN coming from a certificate if it was generated from a more advanced CSR

## Motivation and Context

We want to be able to handle all cases of a Certificate's subject

## Testing

1. Validated regex with several sample strings, including from the original issue
2. Validated change in Set-SSLSecurity.ps1 by passing it varying certificates

## Change Types Made

* [ x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #99 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
