### PR TITLE
(#187) Bump package versions

### DIFF
--- a/Start-C4bCcmSetup.ps1
+++ b/Start-C4bCcmSetup.ps1
@@ -104,7 +104,7 @@ process {
     $chocoArgs = @('install', 'IIS-ApplicationInit', "--source='windowsfeatures'" ,'--no-progress', '-y')
     & choco @chocoArgs
 
-    $chocoArgs = @('install', 'dotnet-aspnetcoremodule-v2', "--version='16.0.23055'", "--source='$Ccr'", '--no-progress', '--pin', '--pin-reason="Latest version compatible with chocolatey-management-web V 0.10.1"', '-y')
+    $chocoArgs = @('install', 'dotnet-aspnetcoremodule-v2', "--version='16.0.23083'", "--source='$Ccr'", '--no-progress', '--pin', '--pin-reason="Latest version compatible with chocolatey-management-web V 0.10.1"', '-y')
     & choco @chocoArgs
 
     $chocoArgs = @('install', 'dotnet-6.0-runtime', "--source='$Ccr'", '--no-progress', '-y')

--- a/Start-C4bJenkinsSetup.ps1
+++ b/Start-C4bJenkinsSetup.ps1
@@ -40,7 +40,7 @@ process {
     & choco @chocoArgs
 
     # Install Jenkins
-    $chocoArgs = @('install', 'jenkins', '-y', "--source='$Source'", '--no-progress', "--version='2.387.1'")
+    $chocoArgs = @('install', 'jenkins', '-y', "--source='$Source'", '--no-progress')
     & choco @chocoArgs
 
     Write-Host "Giving Jenkins 30 seconds to complete background setup..." -ForegroundColor Green


### PR DESCRIPTION
## Description Of Changes
- Bump dotnet-aspnetcoremodule-v2 to V 16.0.23083
- Remove explicit version call of jenkins to now use latest from CCR

## Motivation and Context
Keep guide as up to date package wise as possible.

## Testing
1. Tested upgrades on local test VM

### Operating Systems Testing
- Windows Server 2022

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [X] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [X] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [X] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
Fixes #187 
