### PR TITLE
(#189) Update Jenkins job scripts for choco v2.0.0

### DIFF
--- a/jenkins/scripts/Get-UpdatedPackage.ps1
+++ b/jenkins/scripts/Get-UpdatedPackage.ps1
@@ -16,12 +16,12 @@ Param (
 . "$PSScriptRoot\ConvertTo-ChocoObject.ps1"
 
 Write-Verbose "Getting list of local packages from '$LocalRepo'."
-$localPkgs = choco list --source $LocalRepo -r | ConvertTo-ChocoObject
+$localPkgs = choco search --source $LocalRepo -r | ConvertTo-ChocoObject
 Write-Verbose "Retrieved list of $(($localPkgs).count) packages from '$Localrepo'."
 
 $localPkgs | ForEach-Object {
     Write-Verbose "Getting remote package information for '$($_.name)'."
-    $remotePkg = choco list $_.name --source $RemoteRepo --exact -r | ConvertTo-ChocoObject
+    $remotePkg = choco search $_.name --source $RemoteRepo --exact -r | ConvertTo-ChocoObject
     if ([version]($remotePkg.version) -gt ([version]$_.version)) {
         Write-Verbose "Package '$($_.name)' has a remote version of '$($remotePkg.version)' which is later than the local version '$($_.version)'."
         Write-Verbose "Internalizing package '$($_.name)' with version '$($remotePkg.version)'."

--- a/jenkins/scripts/Update-ProdRepoFromTest.ps1
+++ b/jenkins/scripts/Update-ProdRepoFromTest.ps1
@@ -14,8 +14,8 @@ param (
 )
 
 Write-Verbose "Checking the list of packages available in the test and prod repositories"
-$testPkgs = choco list --source $TestRepo --all-versions --limit-output | ConvertFrom-Csv -Delimiter '|' -Header Name, Version
-$prodPkgs = choco list --source $ProdRepo --all-versions --limit-output | ConvertFrom-Csv -Delimiter '|' -Header Name, Version
+$testPkgs = choco search --source $TestRepo --all-versions --limit-output | ConvertFrom-Csv -Delimiter '|' -Header Name, Version
+$prodPkgs = choco search --source $ProdRepo --all-versions --limit-output | ConvertFrom-Csv -Delimiter '|' -Header Name, Version
 $tempPath = Join-Path -Path $env:TEMP -ChildPath ([GUID]::NewGuid()).GUID
 
 $Packages = if ($null -eq $testPkgs) {


### PR DESCRIPTION

## Description Of Changes

Updates Jenkins job scripts to use `choco search` rather than `choco list` ahead of the v2.0.0 release

## Motivation and Context

The `choco list` command will be limited to locally-installed packages only in the v2.0.0 release of Chocolatey so we need to switch to using `choco search` in all jobs.

## Testing


### Operating Systems Testing


## Change Types Made


* [] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [x] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [x] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [x] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #189
