### PR TITLE
(#193) Remove Jenkins Initial Setup Menus

### DIFF
--- a/Start-C4bJenkinsSetup.ps1
+++ b/Start-C4bJenkinsSetup.ps1
@@ -19,7 +19,7 @@ param(
 )
 
 begin {
-    if($host.name -ne 'ConsoleHost') {
+    if ($host.name -ne 'ConsoleHost') {
         Write-Warning "This script cannot be ran from within PowerShell ISE"
         Write-Warning "Please launch powershell.exe as an administrator, and run this script again"
         break
@@ -39,12 +39,55 @@ process {
     $chocoArgs = @('install', 'temurin11jre', '-y', "--source='$Source'", '--no-progress')
     & choco @chocoArgs
 
+    # Enviornment variable used to disbale jenkins instal login prompts
+    [Environment]::SetEnvironmentVariable('JAVA_OPTS', '-Djenkins.install.runSetupWizard=false', 'Machine')
+
     # Install Jenkins
-    $chocoArgs = @('install', 'jenkins', '-y', "--source='$Source'", '--no-progress')
+    $chocoArgs = @('install', 'jenkins', '--version=2.401.2', '-y', "--source='$Source'", '--no-progress')
     & choco @chocoArgs
 
     Write-Host "Giving Jenkins 30 seconds to complete background setup..." -ForegroundColor Green
     Start-Sleep -Seconds 30  # Jenkins needs a moment
+
+    # Disabling inital setup prompts
+    $JenkinsHome = "C:\ProgramData\Jenkins\.jenkins"
+
+    $JenkinsVersion = (choco list jenkins --exact --limit-output).Split('|')[1]
+    $JenkinsVersion | Out-File -FilePath $JenkinsHome\jenkins.install.UpgradeWizard.state -Encoding utf8
+    $JenkinsVersion | Out-File -FilePath $JenkinsHome\jenkins.install.InstallUtil.lastExecVersion -Encoding utf8
+
+    # Set the external hostname, such that it's ready for use. This may change, but we've pinned Jenkin's version.
+    @"
+<?xml version='1.1' encoding='UTF-8'?>
+<jenkins.model.JenkinsLocationConfiguration>
+<adminAddress>address not configured yet &lt;nobody@nowhere&gt;</adminAddress>
+<jenkinsUrl>http://$($HostName):8080</jenkinsUrl>
+</jenkins.model.JenkinsLocationConfiguration>
+"@ | Out-File -FilePath $JenkinsHome\jenkins.model.JenkinsLocationConfiguration.xml -Encoding utf8
+
+    #region BCrypt Password
+    if (-not (Test-Path "$PSScriptRoot\bcrypt.net.0.1.0\lib\net35\BCrypt.Net.dll")) {
+        $BCryptNugetUri = 'https://www.nuget.org/api/v2/package/BCrypt.Net/0.1.0'
+        $ZipPath = "$PSScriptRoot\bcrypt.net.0.1.0.zip"
+
+        Invoke-WebRequest -Uri $BCryptNugetUri -OutFile $ZipPath -UseBasicParsing
+        Expand-Archive -Path $ZipPath
+    }
+
+    Add-Type -Path "$PSScriptRoot\bcrypt.net.0.1.0\lib\net35\BCrypt.Net.dll"
+    $Salt = [bcrypt.net.bcrypt]::generatesalt(15)
+
+    $JenkinsCred = [System.Net.NetworkCredential]::new(
+        "admin",
+        (New-ServicePassword -Length 32)
+    )
+
+    $AdminUserPath = Resolve-Path "$JenkinsHome\users\admin_*\config.xml"
+    # Can't load as XML document as file is XML v1.1
+    (Get-Content $AdminUserPath) -replace '<passwordHash>#jbcrypt:.+</passwordHash>',
+    "<passwordHash>#jbcrypt:$([bcrypt.net.bcrypt]::hashpassword($JenkinsCred.Password, $Salt))</passwordHash>" |
+    Set-Content $AdminUserPath -Force
+    #endregion
 
     # Long winded way to get the scripts for Jenkins jobs into the right place, but easier to maintain going forward
     $root = Split-Path -Parent $MyInvocation.MyCommand.Definition
@@ -59,98 +102,121 @@ process {
 
     Stop-Service -Name Jenkins
 
-    Write-Host "Updating Jenkins plugins" -ForegroundColor Green
+    #region Jenkins Plugin Install & Update 
+    # Defining required plugins
     $JenkinsPlugins = @{
-        'ant' = '481.v7b_09e538fcca'
+        'ant' = '487.vd79d090d4ea_e'
         'apache-httpcomponents-client-4-api' = '4.5.14-150.v7a_b_9d17134a_5'
-        'bootstrap5-api' = '5.2.2-1'
-        'bouncycastle-api' = '2.27'
-        'branch-api' = '2.1071.v1a_188a_562481'
-        'build-timeout' = '1.28'
-        'caffeine-api' = '2.9.3-65.v6a_47d0f4d1fe'
+        'bootstrap5-api' = '5.2.2-5'
+        'bouncycastle-api' = '2.28'
+        'branch-api' = '2.1092.vda_3c2a_a_f0c11'
+        'build-timeout' = '1.30'
+        'caffeine-api' = '3.1.6-115.vb_8b_b_328e59d8'
         'checks-api' = '2.0.0'
         'commons-lang3-api' = '3.12.0-36.vd97de6465d5b_'
         'commons-text-api' = '1.10.0-36.vc008c8fcda_7b_'
-        'credentials-binding' = '523.vd859a_4b_122e6'
-        'credentials' = '1224.vc23ca_a_9a_2cb_0'
+        'credentials-binding' = '604.vb_64480b_c56ca_'
+        'credentials' = '1254.vb_96f366e7b_a_d'
         'display-url-api' = '2.3.7'
-        'durable-task' = '504.vb10d1ae5ba2f'
-        'echarts-api' = '5.4.0-2'
-        'email-ext' = '2.95'
+        'durable-task' = '507.v050055d0cb_dd'
+        'echarts-api' = '5.4.0-4'
+        'email-ext' = '2.97'
         'cloudbees-folder' = '6.815.v0dd5a_cb_40e0e'
-        'font-awesome-api' = '6.3.0-1'
+        'font-awesome-api' = '6.3.0-2'
         'git-client' = '4.2.0'
-        'git' = '5.0.0'
-        'github-api' = '1.303-417.ve35d9dd78549'
-        'github-branch-source' = '1701.v00cc8184df93'
-        'github' = '1.37.0'
-        'gradle' = '2.3.2'
+        'git' = '5.0.2'
+        'github-api' = '1.314-431.v78d72a_3fe4c3'
+        'github-branch-source' = '1703.vd5a_2b_29c6cdc'
+        'github' = '1.37.1'
+        'gradle' = '2.7'
         'instance-identity' = '142.v04572ca_5b_265'
-        'ionicons-api' = '45.vf54fca_5d2154'
-        'jackson2-api' = '2.14.2-319.v37853346a_229'
+        'ionicons-api' = '56.v1b_1c8c49374e'
+        'jackson2-api' = '2.15.1-344.v6eb_55303dc3e'
         'jakarta-activation-api' = '2.0.1-3'
         'jakarta-mail-api' = '2.0.1-3'
         'jjwt-api' = '0.11.5-77.v646c772fddb_0'
         'javax-activation-api' = '1.2.0-6'
         'javax-mail-api' = '1.6.2-9'
         'jaxb' = '2.3.8-1'
-        'jquery3-api' = '3.6.3-1'
-        'junit' = '1189.v1b_e593637fa_e'
-        'ldap' = '671.v2a_9192a_7419d'
+        'jquery3-api' = '3.7.0-1'
+        'junit' = '1202.v79a_986785076'
+        'ldap' = '682.v7b_544c9d1512'
         'mailer' = '448.v5b_97805e3767'
-        'matrix-auth' = '3.1.6'
-        'matrix-project' = '785.v06b_7f47b_c631'
-        'mina-sshd-api-common' = '2.9.2-50.va_0e1f42659a_a'
-        'mina-sshd-api-core' = '2.9.2-50.va_0e1f42659a_a'
+        'matrix-auth' = '3.1.7'
+        'matrix-project' = '789.v57a_725b_63c79'
+        'mina-sshd-api-common' = '2.10.0-69.v28e3e36d18eb_'
+        'mina-sshd-api-core' = '2.10.0-69.v28e3e36d18eb_'
         'okhttp-api' = '4.10.0-132.v7a_7b_91cef39c'
         'antisamy-markup-formatter' = '159.v25b_c67cd35fb_'
         'pam-auth' = '1.10'
         'workflow-aggregator' = '596.v8c21c963d92d'
         'pipeline-graph-analysis' = '202.va_d268e64deb_3'
-        'workflow-api' = '1208.v0cc7c6e0da_9e'
-        'workflow-basic-steps' = '1010.vf7a_b_98e847c1'
-        'pipeline-build-step' = '487.va_823138eee8b_'
-        'pipeline-model-definition' = '2.2121.vd87fb_6536d1e'
-        'pipeline-model-extensions' = '2.2121.vd87fb_6536d1e'
+        'workflow-api' = '1213.v646def1087f9'
+        'workflow-basic-steps' = '1017.vb_45b_302f0cea_'
+        'pipeline-build-step' = '491.v1fec530da_858'
+        'pipeline-model-definition' = '2.2131.vb_9788088fdb_5'
+        'pipeline-model-extensions' = '2.2131.vb_9788088fdb_5'
         'pipeline-github-lib' = '42.v0739460cda_c4'
-        'workflow-cps' = '3641.vf58904a_b_b_5d8'
-        'pipeline-groovy-lib' = '629.vb_5627b_ee2104'
-        'pipeline-input-step' = '466.v6d0a_5df34f81'
-        'workflow-job' = '1284.v2fe8ed4573d4'
+        'workflow-cps' = '3668.v1763b_b_6ccffd'
+        'pipeline-groovy-lib' = '656.va_a_ceeb_6ffb_f7'
+        'pipeline-input-step' = '468.va_5db_051498a_4'
+        'workflow-job' = '1295.v395eb_7400005'
         'pipeline-milestone-step' = '111.v449306f708b_7'
-        'pipeline-model-api' = '2.2121.vd87fb_6536d1e'
-        'workflow-multibranch' = '733.v109046189126'
-        'workflow-durable-task-step' = '1234.v019404b_3832a'
-        'pipeline-rest-api' = '2.31'
-        'workflow-scm-step' = '400.v6b_89a_1317c9a_'
+        'pipeline-model-api' = '2.2131.vb_9788088fdb_5'
+        'workflow-multibranch' = '746.v05814d19c001'
+        'workflow-durable-task-step' = '1246.v5524618ea_097'
+        'pipeline-rest-api' = '2.32'
+        'workflow-scm-step' = '408.v7d5b_135a_b_d49'
         'pipeline-stage-step' = '305.ve96d0205c1c6'
-        'pipeline-stage-tags-metadata' = '2.2121.vd87fb_6536d1e'
-        'pipeline-stage-view' = '2.31'
+        'pipeline-stage-tags-metadata' = '2.2131.vb_9788088fdb_5'
+        'pipeline-stage-view' = '2.32'
         'workflow-step-api' = '639.v6eca_cd8c04a_a_'
         'workflow-support' = '839.v35e2736cfd5c'
         'plain-credentials' = '143.v1b_df8b_d3b_e48'
-        'plugin-util-api' = '3.1.0'
+        'plugin-util-api' = '3.2.1'
         'powershell' = '2.0'
-        'resource-disposer' = '0.21'
-        'scm-api' = '631.v9143df5b_e4a_a'
-        'script-security' = '1229.v4880b_b_e905a_6'
+        'resource-disposer' = '0.22'
+        'scm-api' = '672.v64378a_b_20c60'
+        'script-security' = '1244.ve463715a_f89c'
         'snakeyaml-api' = '1.33-95.va_b_a_e3e47b_fa_4'
         'ssh-slaves' = '2.877.v365f5eb_a_b_eec'
         'ssh-credentials' = '305.v8f4381501156'
-        'sshd' = '3.275.v9e17c10f2571'
+        'sshd' = '3.303.vefc7119b_ec23'
         'structs' = '324.va_f5d6774f3a_d'
-        'timestamper' = '1.22'
-        'token-macro' = '321.vd7cc1f2a_52c8'
+        'timestamper' = '1.25'
+        'token-macro' = '359.vb_cde11682e0c'
         'trilead-api' = '2.84.v72119de229b_7'
         'variant' = '59.vf075fe829ccb'
-        'ws-cleanup' = '0.44'  
+        'ws-cleanup' = '0.45'
     }
 
+    # Performance is killed by Invoke-WebRequest's progress bars, turning them off to speed this up
+    $ProgressPreference = 'SilentlyContinue'
+
+    # Downloading Jenkins Plugins
+    Write-Host "Downloading Jenkins Plugins"
     foreach ($PluginName in $JenkinsPlugins.Keys) {
-        $PluginUri = 'https://updates.jenkins-ci.org/download/plugins/{0}/{1}/{0}.hpi' -f $PluginName,$JenkinsPlugins[$PluginName]
-        $PluginPath = '{0}/plugins/{1}.hpi' -f $JenkinsHome, $PluginName
-        [System.Net.WebClient]::New().DownloadFile($PluginUri,$PluginPath)
+        $PluginUri = if ($JenkinsPlugins[$PluginName] -ne "latest") {
+            'https://updates.jenkins-ci.org/download/plugins/{0}/{1}/{0}.hpi' -f $PluginName, $JenkinsPlugins[$PluginName]
+        }
+        else {
+            "https://updates.jenkins-ci.org/latest/$($PluginName).hpi"
+        }
+        $PluginPath = '{0}/plugins/{1}.hpi' -f $jenkinsHome, $PluginName
+        if (-not (Test-Path $PluginPath)) {
+            try {
+                Invoke-WebRequest -Uri $PluginUri -OutFile $PluginPath -UseBasicParsing -ErrorAction Stop
+            }
+            catch {
+                # We have internalized the required plugins for jobs we provide
+                Write-Warning "Could not download '$($PluginName)' from '$($PluginUri)': $($_)"
+            }
+        }
     }
+
+    # Restore default progress bar setting
+    $ProgressPreference = 'Continue'
+    #endregion
 
     #region Job Config
     Write-Host "Creating Chocolatey Jobs" -ForegroundColor Green
@@ -159,9 +225,9 @@ process {
 
     Get-ChildItem -Path "$JenkinsHome\jobs" -Recurse -File -Filter 'config.xml' | ForEach-Object {
         (Get-Content -Path $_.FullName -Raw) -replace
-            '{{NugetApiKey}}', $NuGetApiKey -replace
-            '{{hostname}}', $HostName |
-            Set-Content -Path $_.FullName
+        '{{NugetApiKey}}', $NuGetApiKey -replace
+        '{{hostname}}', $HostName |
+        Set-Content -Path $_.FullName
     }
     #endregion
 
@@ -170,16 +236,16 @@ process {
 
     # Save useful params to JSON
     $JenkinsJson = @{
-        JenkinsUri = "http://localhost:8080"
+        JenkinsUri  = "http://$($HostName):8080"
         JenkinsUser = "admin"
-        JenkinsPw = $(Get-Content "$JenkinsHome\secrets\initialAdminPassword")
+        JenkinsPw   = $JenkinsCred.Password
     }
     $JenkinsJson | ConvertTo-Json | Out-File "$env:SystemDrive\choco-setup\logs\jenkins.json"
 
     Write-Host 'Jenkins setup complete' -ForegroundColor Green
-    Write-Host 'Login to Jenkins at: http://locahost:8080' -ForegroundColor Green
+    Write-Host 'Login to Jenkins at: http://$($HostName):8080' -ForegroundColor Green
     Write-Host 'Initial default Jenkins admin user password:' -ForegroundColor Green
-    Write-Host "$(Get-Content "$JenkinsHome\secrets\initialAdminPassword")" -ForegroundColor Green
+    Write-Host "Admin Password is '$($JenkinsCred.Password)'" -ForegroundColor Green
 
     Write-Host 'Writing README to Desktop; this file contains login information for all C4B services.'
     New-QuickstartReadme
@@ -216,10 +282,10 @@ process {
         $Nexus = "https://${hostname}:8443"
         $Jenkins = 'http://localhost:8080'
         try {
-            Start-Process msedge.exe "$Readme","$Ccm", "$Nexus", "$Jenkins"
+            Start-Process msedge.exe "$Readme", "$Ccm", "$Nexus", "$Jenkins"
         }
         catch {
-            Start-Process chrome.exe "$Readme","$Ccm", "$Nexus", "$Jenkins"
+            Start-Process chrome.exe "$Readme", "$Ccm", "$Nexus", "$Jenkins"
         }
     }
 

--- a/jenkins/Internalize packages from the Community Repository/config.xml
+++ b/jenkins/Internalize packages from the Community Repository/config.xml
@@ -59,5 +59,5 @@
     <sandbox>true</sandbox>
   </definition>
   <triggers/>
-  <disabled>true</disabled>
+  <disabled>false</disabled>
 </flow-definition>

--- a/jenkins/Update production repository/config.xml
+++ b/jenkins/Update production repository/config.xml
@@ -55,5 +55,5 @@
     <sandbox>true</sandbox>
   </definition>
   <triggers/>
-  <disabled>true</disabled>
+  <disabled>false</disabled>
 </flow-definition>

--- a/jenkins/Update test repository from Chocolatey Community Repository/config.xml
+++ b/jenkins/Update test repository from Chocolatey Community Repository/config.xml
@@ -39,5 +39,5 @@
     <sandbox>true</sandbox>
   </definition>
   <triggers/>
-  <disabled>true</disabled>
+  <disabled>false</disabled>
 </flow-definition>


### PR DESCRIPTION
## Description Of Changes
- Jenkins version to install is now specified in code to comply with changes to fake a first login.
- We pull down the BCrypt NuGet package to set and encrypt the new admin password within the Jenkins files.
- Jenkins Plugin list was changed to same method used by C4BAE currently.
- Jenkins is configured to be hosted over the hostname of the machine and no longer just localhost.
- Also took the liberty of importing the Jenkins jobs as active by default.

## Motivation and Context
1. Now users can just login to Jenkins and not have to go through first setup menus and then finally be able to login after a wait and reboot.
2. We create the default admin password instead of using the default one that is generated by Jenkins and put on box. Believe this is better security practice.
3. Having the jobs just import turned on seemed like a no-brainer.
4. Updating the plugin logic to mirror C4BAE seemed like the right move. We are later looking to standardize our Jenkins jobs and setup across our various solutions. This way they do not differ and are more maintainable as we look to add further environment solutions offerings.

## Testing
1. Local VM

### Operating Systems Testing
- Windows Server 2022

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [X] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [X] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [X] All new and existing tests passed?
* [X] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #193 
