### PR TITLE
(#197) Clear HTTP cache prior to choco search

### DIFF
--- a/jenkins/scripts/Get-UpdatedPackage.ps1
+++ b/jenkins/scripts/Get-UpdatedPackage.ps1
@@ -15,6 +15,11 @@ Param (
 
 . "$PSScriptRoot\ConvertTo-ChocoObject.ps1"
 
+if (([version] (choco --version).Split('-')[0]) -ge [version] '2.1.0') {
+    Write-Verbose "Clearing Chocolatey CLI cache to ensure latest package information is retrieved."
+    choco cache remove
+}
+
 Write-Verbose "Getting list of local packages from '$LocalRepo'."
 $localPkgs = choco search --source $LocalRepo -r | ConvertTo-ChocoObject
 Write-Verbose "Retrieved list of $(($localPkgs).count) packages from '$Localrepo'."

--- a/jenkins/scripts/Update-ProdRepoFromTest.ps1
+++ b/jenkins/scripts/Update-ProdRepoFromTest.ps1
@@ -13,6 +13,11 @@ param (
     $TestRepo
 )
 
+if (([version] (choco --version).Split('-')[0]) -ge [version] '2.1.0') {
+    Write-Verbose "Clearing Chocolatey CLI cache to ensure latest package information is retrieved."
+    choco cache remove
+}
+
 Write-Verbose "Checking the list of packages available in the test and prod repositories"
 $testPkgs = choco search --source $TestRepo --all-versions --limit-output | ConvertFrom-Csv -Delimiter '|' -Header Name, Version
 $prodPkgs = choco search --source $ProdRepo --all-versions --limit-output | ConvertFrom-Csv -Delimiter '|' -Header Name, Version

--- a/tests/nexus.tests.ps1
+++ b/tests/nexus.tests.ps1
@@ -102,6 +102,10 @@ nexus-args=${jetty.etc}/jetty.xml,${jetty.etc}/jetty-https.xml,${jetty.etc}/jett
 
     Context "Package Availability" {
         BeforeAll {
+            if (([version] (choco --version).Split('-')[0]) -ge [version] '2.1.0') {
+                choco cache remove
+            }
+
             $packages = choco search -s ChocolateyInternal -r | ConvertFrom-Csv -Delimiter '|' -Header Package,Version
         }
 


### PR DESCRIPTION
## Description Of Changes

This PR clears the Chocolaty CLI HTTP Cache that was introduced in v2.0.0 if the host is running Chocolatey CLI 2.1.0 or above, because the command for managing the cache was added in this version.

## Motivation and Context

Subsequent runs of the Jenkins scripts could result in undesired behaviour due to not acting on the latest information/state from remote repositories.

For example:
- The first sync between Test and Prod works as expected, but then a second sync attempts to repush all of the packages again because the cached view of Prod shows it missing all of the packages the first sync pushed.
- If a new package is pushed to Test, then Test to Prod sync may not see the new package as it isn't in the cache and so it will not be synced to Prod.

## Testing

This change has been tested via the C4B Azure Environment project, as the cache was causing test issues when validating an update to that environment.

### Operating Systems Testing

M/A

## Change Types Made

* [X] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #197
