### PR TITLE
Bump CCM Dependencies and Fix Tests

### DIFF
--- a/Start-C4bCcmSetup.ps1
+++ b/Start-C4bCcmSetup.ps1
@@ -104,13 +104,13 @@ process {
     $chocoArgs = @('install', 'IIS-ApplicationInit', "--source='windowsfeatures'" ,'--no-progress', '-y')
     & choco @chocoArgs
 
-    $chocoArgs = @('install', 'dotnet-aspnetcoremodule-v2', "--version='16.0.23170'", "--source='$Ccr'", '--no-progress', '--pin', '--pin-reason="Latest version compatible with chocolatey-management-web V 0.10.1"', '-y')
+    $chocoArgs = @('install', 'dotnet-aspnetcoremodule-v2', "--version='16.0.23172'", "--source='$Ccr'", '--no-progress', '--pin', '--pin-reason="Latest version compatible with chocolatey-management-web V 0.10.1"', '-y')
     & choco @chocoArgs
 
-    $chocoArgs = @('install', 'dotnet-6.0-runtime', '--version=16.0.19', "--source='$Ccr'", '--no-progress', '-y')
+    $chocoArgs = @('install', 'dotnet-6.0-runtime', '--version=6.0.20', "--source='$Ccr'", '--no-progress', '-y')
     & choco @chocoArgs
 
-    $chocoArgs = @('install', 'dotnet-6.0-aspnetruntime', '--version=16.0.19', "--source='$Ccr'", '--no-progress', '-y')
+    $chocoArgs = @('install', 'dotnet-6.0-aspnetruntime', '--version=6.0.20', "--source='$Ccr'", '--no-progress', '-y')
     & choco @chocoArgs
 
     # Install CCM DB package using Local SQL Express

--- a/tests/packages.ps1
+++ b/tests/packages.ps1
@@ -25,7 +25,6 @@ $ServerOnlyPackages = @(
     @{Name = 'Pester' }
     @{Name = 'sql-server-express' }
     @{Name = 'sql-server-management-studio' }
-    @{Name = 'Temurinjre' }
     @{Name = 'Temurin11jre' }
     @{Name = 'vcredist140' }
 )


### PR DESCRIPTION
## Description Of Changes
- Bump dotnet-aspnetcoremodule-v2 to V 16.0.23172
- Bump dotnet-6.0-runtime to V 6.0.20
- Bump dotnet-6.0-aspnetruntime to V 6.0.20

## Motivation and Context
Previous versions in guide didn't exist. As well as keeping guide up to date.

## Testing
1. Local VM Testing

### Operating Systems Testing
- Windows Server 2022

## Change Types Made
* [X] Bug fix (non-breaking change).
* [X] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [X] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?

