### PR TITLE
(#210) Remove DotNet4.5.2 & Internalize ChocolateyGUI

### DIFF
--- a/Start-C4bSetup.ps1
+++ b/Start-C4bSetup.ps1
@@ -162,14 +162,11 @@ process {
     $PkgsDir = "$env:SystemDrive\choco-setup\packages"
     $Ccr = "'https://community.chocolatey.org/api/v2/'"
 
-    # Download Chocolatey community related items, no internalization necessary
-    @('chocolatey', 'chocolateygui') |
-    Foreach-Object {
-        choco download $_ --no-progress --force --source $Ccr --output-directory $PkgsDir
-    }
+    # Download Chocolatey package from Ccr, no internalization necessary
+    choco download 'chocolatey' --no-progress --force --source $Ccr --output-directory $PkgsDir
 
-    # Internalize dotnet4.5.2 for ChocolateyGUI (just in case endpoints need it)
-    choco download dotnet4.5.2 --no-progress --force --internalize --internalize-all-urls --append-use-original-location --source $Ccr  --output-directory $PkgsDir
+    # Internalize chocolateygui & all its dependencies
+    choco download chocolateygui --no-progress --force --internalize --internalize-all-urls --append-use-original-location --source $Ccr  --output-directory $PkgsDir
 
     # Download Licensed Packages
     ## DO NOT RUN WITH `--internalize` and `--internalize-all-urls` - see https://github.com/chocolatey/chocolatey-licensed-issues/issues/155

--- a/tests/packages.ps1
+++ b/tests/packages.ps1
@@ -32,6 +32,5 @@ $RepositoryOnlyPackages = @(
     @{Name = 'chocolatey-dotnetfx.extension' }
     @{Name = 'chocolateygui' }
     @{Name = 'chocolateygui.extension' }
-    @{Name = 'dotnet4.5.2' }
     @{Name = 'dotnetfx' }
 )


### PR DESCRIPTION
## Description Of Changes
- Remove DotNet4.5.2 package
- Change to internalize ChocolateyGUI and it's dependencies from the Chocolatey Community Repository
- 

## Motivation and Context
Remove the DotNet 4.5.2 package as no currently Chocolatey components require this anymore. Change to internalizing the Chocolatey GUI package from CCR to get its dotnetfx dependency. 

## Testing
1. Local VM Test

### Operating Systems Testing

- Windows Server 2022

## Change Types Made

* [X] Bug fix (non-breaking change).
* ~[ ] Feature / Enhancement (non-breaking change).~
* ~[ ] Breaking change (fix or feature that could cause existing functionality to change).~
* ~[ ] Documentation changes.~
* [X] PowerShell code changes.

## Change Checklist

* ~[ ] Requires a change to the documentation.~
* ~[ ] Documentation has been updated.~
* [X] Tests to cover my changes, have been added.
* [X] All new and existing tests passed?
* [X] PowerShell code changes: PowerShell v5.1 compatibility checked?

## Related Issue

Fixes #210 
