### PR TITLE
(#204) Implement NuGet V3 Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Below is the Quick Start Guide as it exists currently on the [Chocolatey Docs](h
 Welcome to the Chocolatey of Business (C4B) Quick-Start Guide! This guide will walk you through the basics of configuring a C4B Server on your VM infrastructure of choice. This includes:
 
 - The Chocolatey Licensed components
-- A NuGet V2 Repository (Nexus)
+- A NuGet V3 Repository (Nexus)
 - Chocolatey Central Management (CCM)
 - An Automation Pipeline (Jenkins)
 
@@ -37,7 +37,7 @@ As illustrated in the diagram above, there are four main components to a Chocola
     - Chocolatey license file (`chocolatey.license.xml`) installed in the correct directory (`ProgramData\chocolatey\license`)
     - Installation of the Chocolatey Licensed extension (`chocolatey.extension`), giving you access to features like Package Builder, Package Internalizer, etc. (full list [here](https://docs.chocolatey.org/en-us/features/)).
 
-1. **NuGet V2 Repository Server App (Nexus)**: Chocolatey works best with a NuGet V2 repository. This application hosts and manages versioning of your Chocolatey package artifacts, in their enhanced NuGet package (.nupkg) file format. The quick start guide helps you setup [Sonatype Nexus Repository Manager (OSS)](https://www.sonatype.com/products/nexus-repository).
+1. **NuGet V3 Repository Server App (Nexus)**: Chocolatey works best with a NuGet V3 repository. This application hosts and manages versioning of your Chocolatey package artifacts, in their enhanced NuGet package (.nupkg) file format. The quick start guide helps you setup [Sonatype Nexus Repository Manager (OSS)](https://www.sonatype.com/products/nexus-repository).
 
 1. **Chocolatey Central Management (CCM)**: CCM is the Web UI portal for your entire Chocolatey environment. Your endpoints check-in to CCM to report their package status. This includes the Chocolatey packages they have installed, and whether any of these packages are outdated. And now, with CCM Deployments, you can also deploy packages or package updates to groups of endpoints, as well as ad-hoc PowerShell commands. CCM is backed by an MS SQL Database. This guide will set up MS SQL Express for you.
 

--- a/Set-SslSecurity.ps1
+++ b/Set-SslSecurity.ps1
@@ -122,7 +122,7 @@ process {
     Write-Host "Nexus is ready!"
 
     choco source remove --name="'ChocolateyInternal'"
-    $RepositoryUrl = "https://${SubjectWithoutCn}:8443/repository/ChocolateyInternal/"
+    $RepositoryUrl = "https://${SubjectWithoutCn}:8443/repository/ChocolateyInternal/index.json"
 
     #Build Credential Object, Connect to Nexus
     $securePw = (Get-Content 'C:\programdata\sonatype-work\nexus3\admin.password') | ConvertTo-SecureString -AsPlainText -Force
@@ -231,7 +231,7 @@ process {
 # Touch NOTHING below this line
 `$User = 'chocouser'
 `$SecurePassword = `$NexusUserPW | ConvertTo-SecureString -AsPlainText -Force
-`$RepositoryUrl = "https://`$(`$fqdn):8443/repository/ChocolateyInternal/"
+`$RepositoryUrl = "https://`$(`$fqdn):8443/repository/ChocolateyInternal/index.json"
 
 `$credential = [pscredential]::new(`$user, `$securePassword)
 

--- a/jenkins/Internalize packages from the Community Repository/config.xml
+++ b/jenkins/Internalize packages from the Community Repository/config.xml
@@ -15,7 +15,7 @@
         <hudson.model.StringParameterDefinition>
           <name>P_DST_URL</name>
           <description>Internal package repository URL.</description>
-          <defaultValue>https://{{hostname}}:8443/repository/ChocolateyTest/</defaultValue>
+          <defaultValue>https://{{hostname}}:8443/repository/ChocolateyTest/index.json</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.PasswordParameterDefinition>

--- a/jenkins/Update production repository/config.xml
+++ b/jenkins/Update production repository/config.xml
@@ -9,7 +9,7 @@
         <hudson.model.StringParameterDefinition>
           <name>P_PROD_REPO_URL</name>
           <description>URL to the production repository</description>
-          <defaultValue>https://{{hostname}}:8443/repository/ChocolateyInternal/</defaultValue>
+          <defaultValue>https://{{hostname}}:8443/repository/ChocolateyInternal/index.json</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.PasswordParameterDefinition>
@@ -20,7 +20,7 @@
         <hudson.model.StringParameterDefinition>
           <name>P_TEST_REPO_URL</name>
           <description>URL for the test repository.</description>
-          <defaultValue>https://{{hostname}}:8443/repository/ChocolateyTest/</defaultValue>
+          <defaultValue>https://{{hostname}}:8443/repository/ChocolateyTest/index.json</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>

--- a/jenkins/Update test repository from Chocolatey Community Repository/config.xml
+++ b/jenkins/Update test repository from Chocolatey Community Repository/config.xml
@@ -9,13 +9,13 @@
         <hudson.model.StringParameterDefinition>
           <name>P_LOCAL_REPO_URL</name>
           <description>Internal test repository.</description>
-          <defaultValue>https://{{hostname}}:8443/repository/ChocolateyTest/</defaultValue>
+          <defaultValue>https://{{hostname}}:8443/repository/ChocolateyTest/index.json</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>P_REMOTE_REPO_URL</name>
           <description>Remote repository containing updated package versions.</description>
-          <defaultValue>https://community.chocolatey.org/api/v2</defaultValue>
+          <defaultValue>https://community.chocolatey.org/api/v2/</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.PasswordParameterDefinition>

--- a/jenkins/scripts/Invoke-ChocolateyInternalizer.ps1
+++ b/jenkins/scripts/Invoke-ChocolateyInternalizer.ps1
@@ -9,7 +9,7 @@
     package.
 
     .EXAMPLE
-    ./Internalizer.ps1 -Package googlechrome -RepositoryUrl https://chocoserver:8443/repository/ChocolateyInternal/ -LocalRepoApiKey 61332b06-d849-476c-b2ab-a290372c17d7
+    ./Internalizer.ps1 -Package googlechrome -RepositoryUrl https://chocoserver:8443/repository/ChocolateyInternal/index.json -LocalRepoApiKey 61332b06-d849-476c-b2ab-a290372c17d7
 #>
 [CmdletBinding()]
 param(
@@ -31,7 +31,7 @@ param(
     # The remote repo to check against. Defaults to https://community.chocolatey.org/api/v2
     [Parameter(Position = 2)]
     [string]
-    $RemoteRepo = 'https://community.chocolatey.org/api/v2'
+    $RemoteRepo = 'https://community.chocolatey.org/api/v2/'
 )
 begin {
     if (!(Test-Path "$env:ChocolateyInstall\license")) {

--- a/scripts/ClientSetup.ps1
+++ b/scripts/ClientSetup.ps1
@@ -9,7 +9,7 @@ param(
     [Parameter()]
     [Alias('Url')]
     [string]
-    $RepositoryUrl = 'https://{{hostname}}:8443/repository/ChocolateyInternal/',
+    $RepositoryUrl = 'https://{{hostname}}:8443/repository/ChocolateyInternal/index.json',
 
     # The credential necessary to access the internal Nexus repository. This can
     # be ignored if Anonymous authentication is enabled.
@@ -85,13 +85,13 @@ if ($Credential) {
 $NupkgUrl = if (-not $ChocolateyVersion) {
     $QueryString = "((Id eq 'chocolatey') and (not IsPrerelease)) and IsLatestVersion"
     $Query = 'Packages()?$filter={0}' -f [uri]::EscapeUriString($queryString)
-    $QueryUrl = ($RepositoryUrl.TrimEnd('/'), $Query) -join '/'
+    $QueryUrl = ($RepositoryUrl.TrimEnd('/index.json'), $Query) -join '/'
 
     [xml]$result = $webClient.DownloadString($QueryUrl)
     $result.feed.entry.content.src
 } else {
     # Otherwise, assume the URL
-    "$($RepositoryUrl.Trim('/'))/chocolatey/$($ChocolateyVersion)"
+    "$($RepositoryUrl.TrimEnd('/index.json'))/chocolatey/$($ChocolateyVersion)"
 }
 
 # Download the NUPKG


### PR DESCRIPTION
## Description Of Changes
- Add ChocolateyInternal as a V3 repo on the server.
- Edit scripts so Register-C4bEndpoint sets up clients using NuGet V3 source.
- Edit Jenkins jobs to use V3 sources.
- Edit README to reflect us using V3 repos with Nexus now.

## Motivation and Context
NuGet V3 feeds are faster to query than V2 feeds.

## Testing
1. Local VM testing

### Operating Systems Testing
1. Windows Server 2022

## Change Types Made

* ~[ ] Bug fix (non-breaking change).~
* ~[ ] Feature / Enhancement (non-breaking change).~
* [X] Breaking change (fix or feature that could cause existing functionality to change).
* ~[ ] Documentation changes.~
* [X] PowerShell code changes.

## Change Checklist

* [X] Requires a change to the documentation.
* [X] Documentation has been updated.
* ~[ ] Tests to cover my changes, have been added.~
* [X] All new and existing tests passed?
* [X] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #204
