### PR TITLE
(#234) Fixes NuGet v3 Localhost Cache Issue

### DIFF
--- a/Start-C4bNexusSetup.ps1
+++ b/Start-C4bNexusSetup.ps1
@@ -68,6 +68,9 @@ process {
             choco push $_.FullName --source "$((Get-NexusRepository -Name 'ChocolateyInternal').url)/index.json" --apikey $NugetApiKey --force
         }
 
+    # Temporary workaround to reset the NuGet v3 cache, such that it doesn't capture localhost as the FQDN
+    Remove-NexusRepositoryFolder -RepositoryName ChocolateyInternal -Name v3
+
     # Add ChocolateyInternal as a source repository
     choco source add -n 'ChocolateyInternal' -s "$((Get-NexusRepository -Name 'ChocolateyInternal').url)/index.json" --priority 1
 

--- a/scripts/Get-Helpers.ps1
+++ b/scripts/Get-Helpers.ps1
@@ -133,7 +133,7 @@ function Connect-NexusServer {
                 Uri         = $url
             }
 
-            $result = Invoke-RestMethod @params -ErrorAction Stop
+            $null = Invoke-RestMethod @params -ErrorAction Stop
             Write-Host "Connected to $Hostname" -ForegroundColor Green
         }
 
@@ -172,16 +172,16 @@ function Invoke-Nexus {
 
         [Parameter(Mandatory)]
         [String]
-        $Method
+        $Method,
 
-
+        [hashtable]
+        $AdditionalHeaders = @{}
     )
     process {
-
         $UriBase = "$($protocol)://$($Hostname):$($port)"
         $Uri = $UriBase + $UriSlug
         $Params = @{
-            Headers     = $header
+            Headers     = $header + $AdditionalHeaders
             ContentType = $ContentType
             Uri         = $Uri
             Method      = $Method
@@ -190,7 +190,7 @@ function Invoke-Nexus {
         if ($Body) {
             $Params.Add('Body', $($Body | ConvertTo-Json -Depth 3))
         } 
-        
+
         if ($BodyAsArray) {
             $Params.Add('Body', $($BodyAsArray | ConvertTo-Json -Depth 3))
         }
@@ -422,6 +422,60 @@ function Remove-NexusRepository {
             catch {
                 $_.exception.message
             }
+        }
+    }
+}
+
+function Remove-NexusRepositoryFolder {
+    <#
+    .SYNOPSIS
+    Removes a given folder from a repository from the Nexus instance
+
+    .PARAMETER RepositoryName
+    The repository to remove from
+
+    .PARAMETER Name
+    The name of the folder to remove
+
+    .EXAMPLE
+    Remove-NexusRepositoryFolder -RepositoryName MyNuGetRepo -Name 'v3'
+    # Removes the v3 folder in the MyNuGetRepo repository
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$RepositoryName,
+
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+    end {
+        if (-not $header) {
+            throw "Not connected to Nexus server! Run Connect-NexusServer first."
+        }
+
+        $ApiParameters = @{
+            UriSlug = "/service/extdirect"
+            Method  = "POST"
+            Body    = @{
+                action = "coreui_Component"
+                method =  "deleteFolder"
+                data   = @(
+                    $Name,
+                    $RepositoryName
+                )
+                type   = "rpc"
+                tid    = Get-Random -Minimum 1 -Maximum 100
+            }
+            AdditionalHeaders = @{
+                "X-Nexus-UI" = "true"
+            }
+        }
+
+        $Result = Invoke-Nexus @ApiParameters
+
+        if (-not $Result.result.success) {
+            throw "Failed to delete folder: $($Result.result.message)"
         }
     }
 }


### PR DESCRIPTION




## Description Of Changes

This commit adds:
- A function to remove existing v3 cache folder(s)
- A call to that function after the Nexus setup script has pushed all of the packages

## Motivation and Context

Nexus Repository stores the first FQDN it hears about for all future requests. As we initially upload packages via localhost, this is less than excellent and breaks future FQDN-based requests.

## Testing
- [please hold]

### Operating Systems Testing
- Windows 2019

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Documentation changes.
* [x] PowerShell code changes.

## Change Checklist

* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?

## Related Issue

Fixes #234 

