### PR TITLE
(#202) Enable Licensed Features In Client Setup and Server

### DIFF
--- a/Start-C4bSetup.ps1
+++ b/Start-C4bSetup.ps1
@@ -131,6 +131,9 @@ process {
         Install-ChocoLicensed -LicenseFile $LicenseFile
     }
 
+    # Set Choco Server Chocolatey Configuration
+    choco feature enable --name="'excludeChocolateyPackagesDuringUpgradeAll'"
+
     # Setup initial choco-setup directories
     Write-Host "Setting up initial directories in"$env:SystemDrive\choco-setup"" -ForegroundColor Green
     $ChocoPath = "$env:SystemDrive\choco-setup"

--- a/scripts/ClientSetup.ps1
+++ b/scripts/ClientSetup.ps1
@@ -126,6 +126,9 @@ choco upgrade chocolateygui.extension -y --source="'ChocolateyInternal'" --no-pr
 
 choco upgrade chocolatey-agent -y --source="'ChocolateyInternal'"
 
+# Chocolatey Package Upgrade Resilience
+choco feature enable --name="'excludeChocolateyPackagesDuringUpgradeAll'"
+
 # Self-Service configuration
 choco feature disable --name="'showNonElevatedWarnings'"
 choco feature enable --name="'useBackgroundService'"


### PR DESCRIPTION
## Description Of Changes
- Add enabling the feature excludeChocolateyPackagesDuringUpgradeAll on the server
- Add enabling the feature showAllPackagesInProgramsAndFeatures on the server
- Add Enhanced Package Reporting section to ClientSetup enabling the showAllPackagesInProgramsAndFeatures feature
- Add Chocolatey Package Upgrade Resilience section to ClientSetup enabling the excludeChocolateyPackagesDuringUpgradeAll feature

## Motivation and Context
Enhance client machine and server package reporting as well as Chocolatey core package upgrade resilience.

## Testing
1. Ran on local VM

### Operating Systems Testing
- Windows Server 2022

## Change Types Made
* [ ] Bug fix (non-breaking change).
* [X] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [X] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?

## Related Issue

Fixes #202 
