### PR TITLE
(#242) Update CCM .Net Dependency Versions and Pins

### DIFF
--- a/Start-C4bCcmSetup.ps1
+++ b/Start-C4bCcmSetup.ps1
@@ -104,13 +104,13 @@ process {
     $chocoArgs = @('install', 'IIS-ApplicationInit', "--source='windowsfeatures'" ,'--no-progress', '-y')
     & choco @chocoArgs
 
-    $chocoArgs = @('install', 'dotnet-aspnetcoremodule-v2', "--version='16.0.23237'", "--source='$Ccr'", '--no-progress', '--pin', '--pin-reason="Latest version compatible with chocolatey-management-web V 0.11.0"', '-y')
+    $chocoArgs = @('install', 'dotnet-aspnetcoremodule-v2', "--version='16.0.24052'", "--source='$Ccr'", '--no-progress', '--pin', '--pin-reason="Latest version compatible with chocolatey-management-web V 0.12.0"', '-y')
     & choco @chocoArgs
 
-    $chocoArgs = @('install', 'dotnet-6.0-runtime', '--version=6.0.22', "--source='$Ccr'", '--no-progress', '-y')
+    $chocoArgs = @('install', 'dotnet-6.0-runtime', '--version=6.0.28', "--source='$Ccr'", '--no-progress', '--pin', '--pin-reason="Latest version compatible with chocolatey-management-database V 0.12.0"', '-y')
     & choco @chocoArgs
 
-    $chocoArgs = @('install', 'dotnet-6.0-aspnetruntime', '--version=6.0.22', "--source='$Ccr'", '--no-progress', '-y')
+    $chocoArgs = @('install', 'dotnet-6.0-aspnetruntime', '--version=6.0.28', "--source='$Ccr'", '--no-progress', '--pin', '--pin-reason="Latest version compatible with chocolatey-management-database V 0.12.0"', '-y')
     & choco @chocoArgs
 
     # Install CCM DB package using Local SQL Express


### PR DESCRIPTION
## Description Of Changes
- Update dotnet-aspnetcoremodule-v2 to V16.0.24052
- Update dotnet-6.0-runtime to V6.0.28
- Update dotnet-6.0-aspnetruntime to V6.0.28
- Update pin message for dotnet-aspnetcoremodule-v2 to reflect current CCM version
- Add pin and pin-reason for dotnet-6.0-runtime package
- Add pin and pin-reason for dotnet-6.0-aspnetruntime package

## Motivation and Context
Keep guide as up to date as possible. Also added addition pins to prevent accidental upgrade of dependencies in wrong order. Known to cause issue with chocolatey-central-management Windows service not starting correctly.

## Testing
- Tested on local VM

### Operating Systems Testing
- Windows Server 2022

## Change Types Made
* [ ] Bug fix (non-breaking change).
* [X] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [X] PowerShell code changes.

## Change Checklist
* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [X] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
Fixes #242