### PR TITLE
Pin Nexus-Repository to mitigate upgrade issues

### DIFF
--- a/Start-C4bNexusSetup.ps1
+++ b/Start-C4bNexusSetup.ps1
@@ -38,9 +38,11 @@ process {
     # Dot-source helper functions
     . .\scripts\Get-Helpers.ps1
 
+    $Packages = (Get-Content $PSScriptRoot\files\chocolatey.json | ConvertFrom-Json).packages
+
     # Install base nexus-repository package
     Write-Host "Installing Sonatype Nexus Repository"
-    $chocoArgs = @('install', 'nexus-repository', '-y' ,'--no-progress', "--package-parameters='/Fqdn:localhost'")
+    $chocoArgs = @('install', 'nexus-repository', "--version=$($Packages.Where{$_.Name -eq 'nexus-repository'}.Version)", '--pin', '-y' ,'--no-progress', "--package-parameters='/Fqdn:localhost'")
     & choco @chocoArgs
 
     #Build Credential Object, Connect to Nexus

--- a/files/chocolatey.json
+++ b/files/chocolatey.json
@@ -24,7 +24,7 @@
         { "name": "KB3035131", "internalize": false },
         { "name": "KB3063858", "internalize": false },
         { "name": "microsoft-edge" },
-        { "name": "nexus-repository" },
+        { "name": "nexus-repository", "version": "3.70.1.2" },
         { "name": "sql-server-express" },
         { "name": "temurin21jre" },
         { "name": "vcredist140" }


### PR DESCRIPTION
## Description Of Changes
This commit pins a specific version of Nexus Repository within the quickstart guide.

## Motivation and Context
The latest version of Nexus-Repository needs special handling for upgrades, and breaks some NuGet v2 behaviour.

Until we have this sorted, we're pinning to the previous version.

## Testing

- [x] Test Deployment

### Operating Systems Testing

- Windows Server 2022

## Change Types Made

* [x] Bug fix (non-breaking change).
* ~[ ] Feature / Enhancement (non-breaking change).~
* ~[ ] Breaking change (fix or feature that could cause existing functionality to change).~
* ~[ ] Documentation changes.~
* [x] PowerShell code changes.

## Change Checklist

* ~[ ] Requires a change to the documentation.~
* ~[ ] Documentation has been updated.~
* ~[ ] Tests to cover my changes, have been added.~
* ~[ ] All new and existing tests passed?~
* ~[ ] PowerShell code changes: PowerShell v3 compatibility checked?~

