### PR TITLE
(#259) Remove Pin for Nexus & Disable usePackageRepositoryOptimizations Feature

### DIFF
--- a/Start-C4bNexusSetup.ps1
+++ b/Start-C4bNexusSetup.ps1
@@ -42,7 +42,7 @@ process {
 
     # Install base nexus-repository package
     Write-Host "Installing Sonatype Nexus Repository"
-    $chocoArgs = @('install', 'nexus-repository', "--version=$($Packages.Where{$_.Name -eq 'nexus-repository'}.Version)", '--pin', '-y' ,'--no-progress', "--package-parameters='/Fqdn:localhost'")
+    $chocoArgs = @('install', 'nexus-repository', '-y' ,'--no-progress', "--package-parameters='/Fqdn:localhost'")
     & choco @chocoArgs
 
     #Build Credential Object, Connect to Nexus

--- a/Start-C4bNexusSetup.ps1
+++ b/Start-C4bNexusSetup.ps1
@@ -90,6 +90,9 @@ process {
         Write-Error "ChocolateyInstall.ps1 script signature is not valid. Please investigate."
     }
 
+    # Nexus NuGet V3 Compatibility
+    choco feature disable --name="'usePackageRepositoryOptimizations'"
+
     # Add ChocolateyInternal as a source repository
     choco source add -n 'ChocolateyInternal' -s "$((Get-NexusRepository -Name 'ChocolateyInternal').url)/index.json" --priority 1
 

--- a/files/chocolatey.json
+++ b/files/chocolatey.json
@@ -24,7 +24,7 @@
         { "name": "KB3035131", "internalize": false },
         { "name": "KB3063858", "internalize": false },
         { "name": "microsoft-edge" },
-        { "name": "nexus-repository", "version": "3.70.1.2" },
+        { "name": "nexus-repository" },
         { "name": "sql-server-express" },
         { "name": "temurin21jre" },
         { "name": "vcredist140" }

--- a/scripts/ClientSetup.ps1
+++ b/scripts/ClientSetup.ps1
@@ -111,6 +111,9 @@ $script = $webClient.DownloadString("https://${hostAddress}/repository/choco-ins
 choco config set cacheLocation $env:ChocolateyInstall\choco-cache
 choco config set commandExecutionTimeoutSeconds 14400
 
+# Nexus NuGet V3 Compatibility
+choco feature disable --name="'usePackageRepositoryOptimizations'"
+
 if ($InternetEnabled) {
     choco source add --name="'ChocolateyInternal'" --source="'$RepositoryUrl'" --allow-self-service --user="'$($Credential.UserName)'" --password="'$($Credential.GetNetworkCredential().Password)'" --priority=1
 }


### PR DESCRIPTION
## Description Of Changes
- Remove pin and version callout of installation of nexus-repository package
- Disable the usePackageRepositoryOptimizations feature on the server and within the ClientSetup script for future endpoints.

## Motivation and Context
Installing the latest version of the nexus-repository package is fine as it just comes with the later H2 DB backend by default.

## Testing
1. Tested with Windows Server 2022 VM, self-signed SSL certificate
2. Tested with Windows Server 2022 VM, wildcard SSL certificate

### Operating Systems Testing
- Windows Server 2022

## Change Types Made
* ~[ ] Bug fix (non-breaking change).~
* [X] Feature / Enhancement (non-breaking change).
* ~[ ] Breaking change (fix or feature that could cause existing functionality to change).~
* ~[ ] Documentation changes.~
* [X] PowerShell code changes.

## Change Checklist

* ~[ ] Requires a change to the documentation.~
* ~[ ] Documentation has been updated.~
* ~[ ] Tests to cover my changes, have been added.~
* [x] All new and existing tests passed?
* ~[ ] PowerShell code changes: PowerShell v3 compatibility checked?~

## Related Issue

Fixes #259 
