### PR TITLE
Remove Ansible Callout From README

### DIFF
--- a/.github/workflows/Helpers.psm1
+++ b/.github/workflows/Helpers.psm1
@@ -1,0 +1,208 @@
+function New-TestVM {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ResourceGroupName,
+
+        [Parameter()]
+        [string]$Name = "qsg-$((New-Guid).ToString() -replace '-' -replace '^(.{11}).+$', '$1')",
+
+        [ValidateSet("Win2022AzureEditionCore", "Win2019Datacenter")]
+        [string]$Image = "Win2022AzureEditionCore",
+
+        [ArgumentCompleter({
+            param($a,$b,$WordToComplete,$d,$e)
+            if (-not $script:VmSizes) {
+                $script:VmSizes = Get-AzVMSize -Location 'eastus2'
+            }
+            $script:VmSizes.Name.Where{$_ -like "*$WordToComplete*"}
+        })]
+        [string]$Size = 'Standard_B4ms'
+    )
+
+    if (-not (Get-AzVM -ResourceGroupName $ResourceGroupName -Name $Name -ErrorAction SilentlyContinue)) {
+        $VmArgs = @{
+            ResourceGroup = $ResourceGroupName
+            Name = $Name
+            PublicIpAddressName = "$Name-ip"
+            DomainNameLabel = $Name
+            PublicIpSku = 'Basic'
+            Image = $Image
+            Size = $Size
+            SecurityGroupName = "$ResourceGroupName-nsg"
+            VirtualNetworkName = "$Name-vnet"
+            NetworkInterfaceDeleteOption = 'Delete'
+            OSDiskDeleteOption = 'Delete'
+            Credential = [PSCredential]::new(
+                'ccmadmin',
+                (ConvertTo-SecureString "$(New-Guid)" -AsPlainText -Force)
+            )
+        }
+
+        Write-Host "Creating VM '$($VmArgs.Name)'"
+        $VM = New-AzVM @VmArgs
+        $VM | Add-Member -MemberType NoteProperty -Name Credential -Value $VmArgs.Credential -PassThru
+    }
+}
+
+function Request-WinRmAccessForTesting {
+    param(
+        [Parameter(Mandatory)]
+        [string]$ResourceGroupName,
+
+        [Parameter()]
+        [string]$VmName,
+
+        [Parameter()]
+        [string]$IpAddress = $(Invoke-RestMethod https://api.ipify.org)
+    )
+    while (!$Success) {
+        if ($NetworkSecurityGroup = Get-AzNetworkSecurityGroup -ResourceGroupName $ResourceGroupName -Name $ResourceGroupName-nsg -ErrorAction SilentlyContinue) {
+            $RuleArgs = @{
+                NetworkSecurityGroup = $NetworkSecurityGroup
+                Name = "AllowWinRMSecure$($IpAddress -replace '\.')"
+                Description = "Allow WinRM over HTTPS for '$($IpAddress)'"
+                Access = "Allow"
+                Protocol = "Tcp"
+                Direction = "Inbound"
+                Priority = 300
+                SourceAddressPrefix = $IpAddress
+                SourcePortRange = "*"
+                DestinationAddressPrefix = "*"
+                DestinationPortRange = 5986
+            }
+    
+            if (($Rules = Get-AzNetworkSecurityRuleConfig -NetworkSecurityGroup $NetworkSecurityGroup).Name -notcontains $RuleArgs.Name) {
+                Write-Host "Adding WinRM Rule to '$($NetworkSecurityGroup.Name)'"
+                while ($Rules.Priority -contains $RuleArgs.Priority) {
+                    $RuleArgs.Priority++
+                }
+                $NewRules = Add-AzNetworkSecurityRuleConfig @RuleArgs
+            }
+        }
+
+        try {
+            $Success = if ($NewRules) {
+                Set-AzNetworkSecurityGroup -NetworkSecurityGroup $NetworkSecurityGroup -ErrorAction Stop
+            } else {
+                $true  # Nothing to do
+            }
+        } catch {
+            if ("$_" -match 'CanceledAndSupersededDueToAnotherOperation') {
+                Write-Verbose "Another operation was occuring on '$($ResourceGroupName)-nsg' - retrying in 30 seconds."
+                Start-Sleep -Seconds 30
+            } else {
+                throw
+            }
+        }
+    }
+
+    if ($VmName) {
+        Write-Host "Enabling Remote PowerShell on '$($VMName)'"
+        $null = Invoke-AzVMRunCommand -ResourceGroupName $ResourceGroupName -Name $VMName -CommandId EnableRemotePS
+    }
+}
+
+function New-HoplessRemotingSession {
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.Runspaces.PSSession])]
+    param(
+        # The address to connect to
+        [Parameter(Mandatory)]
+        [string]$ComputerName,
+        
+        # The credential for the session
+        [Parameter(Mandatory)]
+        [PSCredential]$Credential
+    )
+    Write-Host "Creating remoting session for $($Credential.UserName)@$($ComputerName)"
+    $RemotingArgs = @{
+        ComputerName = $ComputerName
+        Credential = $Credential
+        UseSSL = $true
+        SessionOption = New-PSSessionOption -SkipCACheck -SkipCNCheck
+    }
+    try {
+        $Session = New-PSSession @RemotingArgs -ConfigurationName Hopless -ErrorAction Stop
+    } catch [System.Management.Automation.Remoting.PSRemotingTransportException] {
+        if ($_.Exception.Message -match 'Cannot find the Hopless session configuration') {
+            Write-Host "Creating Hopless Configuration for $($Credential.UserName)@$($ComputerName)"
+            # This throws an error when the session terminates, so we catch the PSRemotingTransportException 
+            try {
+                $null = Invoke-Command @RemotingArgs {
+                    Register-PSSessionConfiguration -Name "Hopless" -RunAsCredential $using:Credential -Force -WarningAction SilentlyContinue
+                } -ErrorAction Stop
+            } catch [System.Management.Automation.Remoting.PSRemotingTransportException] {}
+        
+            Start-Sleep -Seconds 30  # Hate this, but just testing the idea out.
+        
+            Write-Verbose "Recreating Session after WinRM restart..."
+            $Timeout = [System.Diagnostics.Stopwatch]::StartNew()
+            while ($Session.Availability -ne 'Available' -and $Timeout.Elapsed.TotalSeconds -lt 180) {
+                try {
+                    $Session = New-PSSession @RemotingArgs -ConfigurationName Hopless
+                } catch {
+                    Start-Sleep -Seconds 5
+                }
+            }
+
+            if ($Session.Availability -ne 'Available') {
+                $Session
+                Write-Error "Failed to re-establish a connection to '$($ComputerName)'"
+            } else {
+                Write-Host "Successfully reconnected after '$($Timeout.Elapsed.TotalSeconds)' seconds" 
+            }
+        } else {throw}
+    }
+    return $Session
+}
+
+function Install-DotNet {
+    [OutputType([int32])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ParameterSetName = 'Separate')]
+        [string]$ComputerName,
+
+        [Parameter(Mandatory, ParameterSetName = 'Separate')]
+        [PSCredential]$Credential,
+
+        [Parameter(Mandatory, ParameterSetName = 'Session')]
+        [System.Management.Automation.Runspaces.PSSession]$Session,
+
+        [string]$DownloadPath = 'https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe'
+    )
+    # Install Dotnet 4.8 if required
+    $RequiresDotnet = Invoke-Command -Session $Session -ScriptBlock {
+        (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full" -ErrorAction SilentlyContinue).Release -lt 528040
+    }
+
+    if ($RequiresDotnet) {
+        Write-Host "Installing Dotnet 4.8 to '$($ComputerName)'"
+        $DotnetInstall = Invoke-Command -Session $Session -ScriptBlock {
+            $NetFx48Url = $using:DownloadPath
+            $NetFx48Path = $env:TEMP
+            $NetFx48InstallerFile = 'ndp48-x86-x64-allos-enu.exe'
+            $NetFx48Installer = Join-Path $NetFx48Path $NetFx48InstallerFile
+            if (!(Test-Path $NetFx48Installer)) {
+                Write-Host "Downloading `'$NetFx48Url`' to `'$NetFx48Installer`'"
+                (New-Object Net.WebClient).DownloadFile("$NetFx48Url","$NetFx48Installer")
+            }
+
+            $psi = New-Object System.Diagnostics.ProcessStartInfo
+            $psi.WorkingDirectory = "$NetFx48Path"
+            $psi.FileName = "$NetFx48InstallerFile"
+            $psi.Arguments = "/q /norestart"
+
+            Write-Host "Installing `'$NetFx48Installer`'"
+            $s = [System.Diagnostics.Process]::Start($psi);
+            $s.WaitForExit();
+
+            return $s.ExitCode
+        }
+
+        return $DotnetInstall
+    } else {
+        return 0  # No work performed / success
+    }
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,394 @@
+name: Test Deployment
+
+on:
+  workflow_dispatch:
+    inputs:
+      ignore_cache:
+        description: Does not restore a package cache if selected.
+        required: false
+        type: boolean
+
+      vm_size:
+        description: The size of VM to spin up.
+        default: Standard_B4ms # Standard_B4as_v2
+
+      images:
+        description: The Azure images to test on.
+        default: Win2022AzureEditionCore, Win2019Datacenter
+        type: string
+
+      variants:
+        description: The configurations to test with.
+        default: self-signed, single, wildcard
+
+  pull_request:
+    paths:
+      - files/**.json
+      - "**.ps1"
+      - scripts/**.ps1
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+# May want to remove this, as though it's neat to only have one job running per 
+# ref, it may cancel before cleanup has happened.
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  matrix:
+    name: Generate Testing Parameters
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Test Matrix
+        id: test-matrix
+        shell: pwsh
+        run: |
+          $EventType = '${{ github.event_name }}'
+          $AuthHeaders = @{Headers = @{Authorization = 'Bearer ${{ secrets.GITHUB_TOKEN }}'}}
+          $GitHubApi = '${{ github.api_url }}'
+          switch ($EventType) {
+            'workflow_dispatch' {
+              # We have been triggered manually. Run the inputs!
+              $Images = (-split '${{ inputs.images }}').Trim(',;')
+              $Variants = (-split '${{ inputs.variants }}').Trim(',;')
+            }
+            'pull_request' {
+              # This is a pull request. If it's from a known maintainer, run a test - otherwise, exit.
+              $Trigger = Invoke-RestMethod "$GitHubApi/repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission" @AuthHeaders
+
+              if ($Trigger.Permission -in @("admin", "write")) {
+                $Images = "Win2022AzureEditionCore", "Win2019Datacenter"
+                $Variants = "self-signed", "single", "wildcard"
+              } else {
+                Write-Error "Action was triggered by '${{ github.actor }}', who has '$TriggerPermission': Cancelling build."
+                exit 1
+              }
+            }
+          }
+          "images=$($Images | ConvertTo-Json -Compress -AsArray)" >> $env:GITHUB_OUTPUT
+          "variants=$($Variants | ConvertTo-Json -Compress -AsArray)" >> $env:GITHUB_OUTPUT
+
+    outputs:
+      matrix-os: ${{ steps.test-matrix.outputs.images }}
+      matrix-variant: ${{ steps.test-matrix.outputs.variants }}
+
+  build:
+    name: Build Package Cache
+    needs: matrix
+    if: success()
+    runs-on: windows-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Create License File
+        run: |
+          if (-not (Test-Path C:\choco-setup\files)) {
+            New-Item -Path C:\choco-setup\files -ItemType Junction -Value $PWD.Path
+          }
+          $LicenseDir = Join-Path $env:ChocolateyInstall 'license'
+          if (-not (Test-Path $LicenseDir)) {$null = mkdir $LicenseDir}
+          Set-Content -Path $LicenseDir\chocolatey.license.xml -Value $(
+            [System.Text.Encoding]::UTF8.GetString(
+              [System.Convert]::FromBase64String('${{ secrets.LICENSE }}')
+            )
+          )
+
+      - name: Setup Package Cache
+        uses: actions/cache@v4
+        if: inputs.ignore_cache != true
+        with:
+          path: |
+            C:/choco-setup/files/files/*.nupkg
+            C:/choco-setup/files/files/*.zip
+            !**/chocolatey-license.*.nupkg
+          key: "${{ hashFiles('files/*.json') }}"
+
+      - name: Begin Setup
+        run: C:\choco-setup\files\OfflineInstallPreparation.ps1
+
+      - name: Upload Built Artifact
+        id: build-upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: choco-packages
+          path: |
+            C:\choco-setup\files\*
+            !C:\choco-setup\files\.git*
+            !chocolatey-license.*.nupkg
+            !C:\choco-setup\files\files\chocolatey.license.xml
+
+    outputs:
+      artifact-url: ${{ steps.build-upload.outputs.artifact-url }}
+
+  runner_test_deploy:
+    strategy:
+      matrix:
+        os: ${{ fromJson(needs.matrix.outputs.matrix-os) }}
+        variant: ${{ fromJson(needs.matrix.outputs.matrix-variant) }}
+      fail-fast: false
+    name: ${{ matrix.os }} with ${{ matrix.variant }} certificate
+    runs-on: windows-latest
+    needs: [build, matrix]
+    if: success()
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          enable-AzPSSession: true
+
+      - name: Deploy '${{ matrix.os }}' VM
+        id: deploy-vm
+        uses: azure/powershell@v2
+        with:
+          inlineScript: |
+            Import-Module .\.github\workflows\Helpers.psm1
+
+            $Location = 'eastus2'
+            $ResourceGroupName = "qsg-testing"
+            if ('${{ github.run_id }}' -ne "`$`{{ github.run_id }}") {$ResourceGroupName += '-${{ github.run_id }}'}
+
+            if (-not (Get-AzResourceGroup -ResourceGroupName $ResourceGroupName -ErrorAction SilentlyContinue)) {
+              $null = New-AzResourceGroup -ResourceGroupName $ResourceGroupName -Location $Location -Force -Tag @{
+                CreatedBy = '${{ github.triggering_actor }}'
+                Ref = '${{ github.ref }}'
+                Until = (Get-Date (Get-Date).AddHours(1) -F 'yyyy/MM/dd')
+                Commit = '${{ github.sha }}'
+              }
+            }
+
+            $VMArgs = @{
+              Image = '${{ matrix.os }}'
+              Size = [string]::IsNullOrEmpty('${{ inputs.vm_size }}') ? 'Standard_B4as_v2' : '${{ inputs.vm_size }}'
+            }
+            $VM = New-TestVM -ResourceGroupName $ResourceGroupName @VMArgs
+
+            # Set NSG to have access
+            Request-WinRmAccessForTesting -ResourceGroupName $ResourceGroupName -VmName $VM.Name
+
+            $Session = New-HoplessRemotingSession -ComputerName $Vm.FullyQualifiedDomainName -Credential $Vm.Credential
+
+            # Windows Server 2019 may require Dotnet 4.8 to be installed, and have a reboot
+            $DotnetInstall = Install-Dotnet -Session $Session
+            if ($DotnetInstall -eq 1641 -or $DotnetInstall -eq 3010) {
+              Write-Host ".NET Framework 4.8 was installed, but a reboot is required before using Chocolatey CLI."
+              $Reboot = Restart-AzVm -ResourceGroupName $ResourceGroupName -Name $VM.Name
+              if ($Reboot.Status -eq 'Succeeded') {
+                Write-Host "Reboot was successful after $($Reboot.Endtime - $Reboot.Starttime)"
+              }
+
+              # Recreate the session
+              $Session = New-HoplessRemotingSession -ComputerName $Vm.FullyQualifiedDomainName -Credential $Vm.Credential
+            }
+
+            try {
+              $DownloadUrl = if ('${{ needs.build.outputs.artifact-url }}' -match 'https://github.com/(?<Owner>.+)/(?<Repository>.+)/actions/runs/(?<RunId>\d+)/artifacts/(?<ArtifactId>\d+)') {
+                "https://api.github.com/repos/$($Matches.Owner)/$($Matches.Repository)/actions/artifacts/$($Matches.ArtifactId)/zip"
+              } else {
+                '${{ needs.build.outputs.artifact-url }}'
+              }
+              Write-Host "Downloading Build Artifact '$DownloadUrl' to '$($VM.Name)' @$(Get-Date -Format o)"
+              Invoke-Command -Session $Session -ScriptBlock {
+                if (-not (Test-Path C:\choco-setup\files)) {$null = mkdir C:\choco-setup\files -Force}
+                $ProgressPreference = "SilentlyContinue"
+                $Response = Invoke-WebRequest -Uri $using:DownloadUrl -UseBasicParsing -Headers @{
+                  Authorization = "Bearer ${{ secrets.GITHUB_TOKEN }}"
+                  Accept = "application/vnd.github+json"
+                  "X-GitHub-Api-Version" = "2022-11-28"
+                } -OutFile C:\choco-setup\files.zip
+                Expand-Archive -Path C:\choco-setup\files.zip -DestinationPath C:\choco-setup\files\
+              }
+            } finally {
+              Write-Host "Finished Downloading @$(Get-Date -Format o)"
+            }
+
+            Write-Host "Creating License File on '$($VM.Name)'"
+            Invoke-Command -Session $Session -ScriptBlock {
+              Set-Content -Path C:\choco-setup\files\files\chocolatey.license.xml -Value $(
+                [System.Text.Encoding]::UTF8.GetString(
+                  [System.Convert]::FromBase64String('${{ secrets.LICENSE }}')
+                )
+              )
+            }
+
+            Write-Host "Setting up '${{ matrix.variant }}' Certificate"
+            $Certificate = switch ('${{ matrix.variant }}') {
+              'self-signed' {
+                Write-Host "Creating a Self-Signed Certificate for '$($Vm.Name)'"
+                $CertDetails = @{FQDN = $Vm.Name}
+                @{Hostname = $CertDetails.FQDN}
+              }
+              'single' {
+                $CertDetails = Invoke-Command -Session $Session -ScriptBlock {
+                  $Cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
+                    [Convert]::FromBase64String('${{ secrets.SINGLE_CERT }}'),
+                    (ConvertTo-SecureString '${{ secrets.SINGLE_PASS }}' -AsPlainText -Force),
+                    ("Exportable", "PersistKeySet", "MachineKeySet")
+                  )
+
+                  $Store = [System.Security.Cryptography.X509Certificates.X509Store]::new("TrustedPeople", "LocalMachine")
+                  $Store.Open("ReadWrite")
+                  $null = $Store.Add($Cert)
+
+                  Add-Content $env:windir\system32\drivers\etc\hosts -Value "127.0.0.1 $($Cert.Subject -replace '^CN=')"
+
+                  @{
+                    Thumbprint = $Cert.Thumbprint
+                    FQDN = $Cert.Subject -replace '^CN='
+                  }
+                }
+                Write-Host "Using Certificate with Thumbprint '$($Thumbprint)'"
+                @{Thumbprint = $CertDetails.Thumbprint; Hardened = $true}
+              }
+              'wildcard' {
+                $CertDetails = Invoke-Command -Session $Session -ScriptBlock {
+                  $Cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
+                    [Convert]::FromBase64String('${{ secrets.WILDCARD_CERT }}'),
+                    (ConvertTo-SecureString '${{ secrets.WILDCARD_PASS }}' -AsPlainText -Force),
+                    ("Exportable", "PersistKeySet", "MachineKeySet")
+                  )
+
+                  $Store = [System.Security.Cryptography.X509Certificates.X509Store]::new("TrustedPeople", "LocalMachine")
+                  $Store.Open("ReadWrite")
+                  $null = $Store.Add($Cert)
+
+                  Add-Content $env:windir\system32\drivers\etc\hosts -Value "127.0.0.1 $($Cert.Subject -replace '^CN=\*',$env:ComputerName)"
+
+                  @{
+                    Thumbprint = $Cert.Thumbprint
+                    FQDN = $Cert.Subject -replace '^CN=\*',$env:ComputerName
+                  }
+                }
+                Write-Host "Using Wildcard with Thumbprint '$($Thumbprint)'"
+                @{Thumbprint = $CertDetails.Thumbprint; CertificateDnsName = $CertDetails.FQDN; Hardened = $true}
+              }
+            }
+
+            try {
+              Write-Host "Installing QuickStart Guide on '$($VM.Name)'"
+              $DatabaseCredential = [PSCredential]::new(
+                'ccmdbuser',
+                (ConvertTo-SecureString "$(New-Guid)" -AsPlainText -Force)
+              )
+              $Timer = [System.Diagnostics.Stopwatch]::StartNew()
+              Invoke-Command -Session $Session -ScriptBlock {
+                C:\choco-setup\files\Start-C4bSetup.ps1
+                C:\choco-setup\files\Start-C4BNexusSetup.ps1
+                C:\choco-setup\files\Start-C4bCcmSetup.ps1 -DatabaseCredential $using:DatabaseCredential
+                C:\choco-setup\files\Start-C4bJenkinsSetup.ps1
+                C:\choco-setup\files\Set-SslSecurity.ps1 @using:Certificate
+              }
+              $Timer.Stop()
+              "deployment-time=$($Timer.Elapsed)" >> $env:GITHUB_OUTPUT
+
+              # Run Tests
+              Write-Host "Running Verification Tests on '$($VM.Name)'"
+              $RemotingArgs = @{
+                ComputerName = $VM.FullyQualifiedDomainName
+                Credential = $VM.Credential
+                UseSSL = $true
+                SessionOption = New-PSSessionOption -SkipCACheck -SkipCNCheck
+              }
+              $TestResults = Invoke-Command -Session $Session -ScriptBlock {
+                if (-not (Get-Module Pester -ListAvailable).Where{$_.Version -gt "5.0"}) {
+                  Write-Host "Installing Pester 5 to run validation tests"
+                  $chocoArgs = @('install', 'pester', '-y', '--source="https://community.chocolatey.org/api/v2/"')
+                  & choco @chocoArgs | Write-Host
+                }
+                (Get-ChildItem C:\choco-setup\files\tests\ -Recurse -Filter *.tests.ps1).Fullname
+              } | ForEach-Object {
+                Invoke-Command @RemotingArgs -ScriptBlock {
+                  param(
+                    $Path
+                  )
+                  . C:\choco-setup\files\scripts\Get-Helpers.ps1
+                  $configuration = New-PesterConfiguration @{
+                    Run        = @{
+                      Container = New-PesterContainer -Path $Path -Data @{ Fqdn = $using:CertDetails.FQDN }
+                      Passthru  = $true
+                    }
+                    Output     = @{
+                      Verbosity = 'Detailed'
+                    }
+                    TestResult = @{
+                      Enabled      = $true
+                      OutputFormat = 'NUnitXml'
+                      OutputPath   = "C:\choco-setup\test-results\${{ matrix.os }}-${{ matrix.variant }}-$((Split-Path $Path -Leaf) -replace '.tests.ps1$')-verification.results.xml"
+                    }
+                  }
+
+                  Invoke-Pester -Configuration $configuration
+                } -ArgumentList $_
+              }
+            } finally {
+              Write-Host "Copying Results from '$($VM.Name)' @$(Get-Date -Format o)"
+              if (-not (Test-Path .\logs\ -PathType Container)) {$null = mkdir .\logs\}
+              Copy-Item -FromSession $Session -Path C:\choco-setup\logs\* -Destination .\logs\ -ErrorAction SilentlyContinue
+              Copy-Item -FromSession $Session -Path C:\choco-setup\test-results\* -Destination .\logs\ -ErrorAction SilentlyContinue
+            }
+          azPSVersion: latest
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action/windows@v2
+        if: success()
+        with:
+          check_name: C4bVerification-${{ matrix.os }}-${{ matrix.variant }}
+          comment_mode: failures
+          files: |
+            logs\*-verification.results.xml
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Log Files
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: choco-setup-logs-${{ matrix.os }}-${{ matrix.variant }}
+          path: logs\*.txt
+
+  cleanup:
+    name: Cleanup Test Resources
+    runs-on: ubuntu-latest
+    needs: [build, runner_test_deploy]
+    if: success() || failure()
+    steps:
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          enable-AzPSSession: true
+
+      - name: Destroy Remaining Resources
+        uses: azure/powershell@v2
+        with:
+          inlineScript: |
+            if ('${{ needs.build.outputs.artifact-url }}' -match 'https://github.com/(?<Owner>.+)/(?<Repository>.+)/actions/runs/(?<RunId>\d+)/artifacts/(?<ArtifactId>\d+)') {
+              $DeleteArgs = @{
+                Uri = "https://api.github.com/repos/$($Matches.Owner)/$($Matches.Repository)/actions/artifacts/$($Matches.ArtifactId)"
+                Method = "DELETE"
+                Headers = @{
+                  Authorization = "Bearer ${{ secrets.GITHUB_TOKEN }}"
+                  Accept = "application/vnd.github+json"
+                  "X-GitHub-Api-Version" = "2022-11-28"
+                }
+              }
+              Invoke-RestMethod @DeleteArgs
+            }
+
+            $ResourceGroupName = "qsg-testing"
+            if ('${{ github.run_id }}' -ne "`$`{{ github.run_id }}") {$ResourceGroupName += '-${{ github.run_id }}'}
+            if (Get-AzResourceGroup -ResourceGroupName $ResourceGroupName -ErrorAction SilentlyContinue) {
+              Remove-AzResourceGroup -ResourceGroupName $ResourceGroupName -Force  # -AsJob
+            }
+          azPSVersion: latest

--- a/Start-C4bCcmSetup.ps1
+++ b/Start-C4bCcmSetup.ps1
@@ -21,16 +21,6 @@ param(
     [String]
     $CertificateThumbprint
 )
-
-begin {
-    if($host.name -ne 'ConsoleHost') {
-        Write-Warning "This script cannot be ran from within PowerShell ISE"
-        Write-Warning "Please launch powershell.exe as an administrator, and run this script again"
-        break
-    }
-}
-
-
 process {
     $DefaultEap = $ErrorActionPreference
     $ErrorActionPreference = 'Stop'

--- a/Start-C4bJenkinsSetup.ps1
+++ b/Start-C4bJenkinsSetup.ps1
@@ -16,16 +16,6 @@ param(
     # API key of your Nexus repo, for Chocolatey Jenkins jobs to use
     [string]$NuGetApiKey = $(Get-Content "$env:SystemDrive\choco-setup\logs\nexus.json" | ConvertFrom-Json).NuGetApiKey
 )
-
-begin {
-    if ($host.name -ne 'ConsoleHost') {
-        Write-Warning "This script cannot be ran from within PowerShell ISE"
-        Write-Warning "Please launch powershell.exe as an administrator, and run this script again"
-        break
-    }
-}
-
-
 process {
     $DefaultEap = $ErrorActionPreference
     $ErrorActionPreference = 'Stop'

--- a/Start-C4bNexusSetup.ps1
+++ b/Start-C4bNexusSetup.ps1
@@ -20,16 +20,6 @@ param(
     [string]
     $Browser = 'Edge'
 )
-
-begin {
-    if($host.name -ne 'ConsoleHost') {
-        Write-Warning "This script cannot be ran from within PowerShell ISE"
-        Write-Warning "Please launch powershell.exe as an administrator, and run this script again"
-        break
-    }
-}
-
-
 process {
     $DefaultEap = $ErrorActionPreference
     $ErrorActionPreference = 'Stop'

--- a/Start-C4bSetup.ps1
+++ b/Start-C4bSetup.ps1
@@ -75,13 +75,6 @@ param(
     [Alias('PR')]
     $Branch = $env:CHOCO_QSG_BRANCH
 )
-
-if ($host.name -ne 'ConsoleHost') {
-    Write-Warning "This script cannot be ran from within PowerShell ISE"
-    Write-Warning "Please launch powershell.exe as an administrator, and run this script again"
-    break
-}
-
 if ($ShowChocoOutput) {
     $global:PSDefaultParameterValues["Invoke-Choco:InformationAction"] = "Continue"
 }

--- a/Start-C4bVerification.ps1
+++ b/Start-C4bVerification.ps1
@@ -11,9 +11,11 @@ process {
     $Helpers = Join-Path $HelperPath -ChildPath 'Get-Helpers.ps1'
     . $Helpers
 
-    Write-Host "Installing Pester 5 to run validation tests"
-    $chocoArgs = @('install', 'pester', '-y', '--source="https://community.chocolatey.org/api/v2/"')
-    & choco @chocoArgs
+    if (-not (Get-Module Pester -ListAvailable).Where{$_.Version -gt "5.0"}) {
+        Write-Host "Installing Pester 5 to run validation tests"
+        $chocoArgs = @('install', 'pester', '-y', '--no-progress', '--source="https://community.chocolatey.org/api/v2/"')
+        & choco @chocoArgs
+    }
 
     $files = (Get-ChildItem C:\choco-setup\files\tests\ -Recurse -Filter *.ps1).Fullname
     Write-Host "Configuring Pester to complete verification tests"

--- a/scripts/Get-Helpers.ps1
+++ b/scripts/Get-Helpers.ps1
@@ -20,7 +20,18 @@ function Invoke-Choco {
         $Arguments += '--limit-output'
     }
 
-    & choco.exe $Command $Arguments | Tee-Object -Variable Result | Where-Object {$_} | ForEach-Object {
+    $chocoPath = if ($CommandPath = Get-Command choco.exe -ErrorAction SilentlyContinue) {
+        $CommandPath.Source
+    } elseif ($env:ChocolateyInstall) {
+        Join-Path $env:ChocolateyInstall "choco.exe"
+    } elseif (Test-Path C:\ProgramData\chocolatey\choco.exe) {
+        "C:\ProgramData\chocolatey\choco.exe"
+    } else {
+        Write-Error "Could not find 'choco.exe' - unexpected behaviour is expected!"
+        "choco.exe"
+    }
+
+    & $chocoPath $Command $Arguments | Tee-Object -Variable Result | Where-Object {$_} | ForEach-Object {
         Write-Information -MessageData $_ -Tags Choco
     }
 
@@ -1634,52 +1645,80 @@ function Get-RemoteCertificate {
     }
 }
 
-function New-NexusCert {
+function Set-NexusCert {
     [CmdletBinding()]
     param(
-        [Parameter()]
-        $Thumbprint
+        # The thumbprint of the certificate to configure Nexus to use, from the LocalMachine\TrustedPeople store.
+        [Parameter(Mandatory)]
+        $Thumbprint,
+
+        # The port to set Nexus to use for https.
+        $Port = 8443
     )
 
-    if ((Test-Path C:\ProgramData\nexus\etc\ssl\keystore.jks)) {
-        Remove-Item C:\ProgramData\nexus\etc\ssl\keystore.jks -Force
+    $KeyTool = "C:\ProgramData\nexus\jre\bin\keytool.exe"
+    $KeyStorePath = 'C:\ProgramData\nexus\etc\ssl\keystore.jks'
+    $KeystoreCredential = [System.Net.NetworkCredential]::new(
+        "Keystore",
+        (New-ServicePassword)
+    )
+    $TempCertPath = Join-Path $env:TEMP "$(New-Guid).pfx"
+
+    try {
+        # Temporarily export the certificate as a PFX
+        Get-ChildItem Cert:\LocalMachine\TrustedPeople\ | Where-Object { $_.Thumbprint -eq $Thumbprint } | Sort-Object | Select-Object -First 1 | Export-PfxCertificate -FilePath $TempCertPath -Password $KeystoreCredential.SecurePassword
+        # TODO: Is this the right place for this? # Get-ChildItem -Path $TempCertPath | Import-PfxCertificate -CertStoreLocation Cert:\LocalMachine\My -Exportable -Password $KeystoreCredential.SecurePassword
+        
+        if (Test-Path $KeyStorePath) {
+            Remove-Item $KeyStorePath -Force
+        }
+
+        # Using a job to hide improper non-output streams
+        $Job = Start-Job {
+            $string = ($using:KeystoreCredential.Password | & $using:KeyTool -list -v -keystore $using:TempCertPath) -match '^Alias.*'
+            $currentAlias = ($string -split ':')[1].Trim()
+            & $using:KeyTool -importkeystore -srckeystore $using:TempCertPath -srcstoretype PKCS12 -srcstorepass $using:KeystoreCredential.Password -destkeystore $using:KeyStorePath -deststoretype JKS -alias $currentAlias -destalias jetty -deststorepass $using:KeystoreCredential.Password
+            & $using:KeyTool -keypasswd -keystore $using:KeyStorePath -alias jetty -storepass $using:KeystoreCredential.Password -keypass $using:KeystoreCredential.Password -new $using:KeystoreCredential.Password
+        } | Wait-Job
+        if ($Job.State -eq 'Failed') {
+            $Job | Receive-Job
+        } else {
+            $Job | Remove-Job
+        }
+    } finally {
+        if (Test-Path $TempCertPath) {
+            Remove-Item $TempCertPath -Force
+        }
     }
 
-    $KeyTool = "C:\ProgramData\nexus\jre\bin\keytool.exe"
-    $password = "chocolatey" | ConvertTo-SecureString -AsPlainText -Force
-    $certificate = Get-ChildItem  Cert:\LocalMachine\TrustedPeople\ | Where-Object { $_.Thumbprint -eq $Thumbprint } | Sort-Object | Select-Object -First 1
-
-    Write-Host "Exporting .pfx file to C:\, will remove when finished" -ForegroundColor Green
-    $certificate | Export-PfxCertificate -FilePath C:\cert.pfx -Password $password
-    Get-ChildItem -Path c:\cert.pfx | Import-PfxCertificate -CertStoreLocation Cert:\LocalMachine\My -Exportable -Password $password
-    Write-Warning -Message "You'll now see prompts and other outputs, things are working as expected, don't do anything"
-    $string = ("chocolatey" | & $KeyTool -list -v -keystore C:\cert.pfx) -match '^Alias.*'
-    $currentAlias = ($string -split ':')[1].Trim()
-
-    $passkey = '9hPRGDmfYE3bGyBZCer6AUsh4RTZXbkw'
-    & $KeyTool -importkeystore -srckeystore C:\cert.pfx -srcstoretype PKCS12 -srcstorepass chocolatey -destkeystore C:\ProgramData\nexus\etc\ssl\keystore.jks -deststoretype JKS -alias $currentAlias -destalias jetty -deststorepass $passkey
-    & $KeyTool -keypasswd -keystore C:\ProgramData\nexus\etc\ssl\keystore.jks -alias jetty -storepass $passkey -keypass chocolatey -new $passkey
-
+    # Update the Nexus configuration
     $xmlPath = 'C:\ProgramData\nexus\etc\jetty\jetty-https.xml'
     [xml]$xml = Get-Content -Path 'C:\ProgramData\nexus\etc\jetty\jetty-https.xml'
     foreach ($entry in $xml.Configure.New.Where{ $_.id -match 'ssl' }.Set.Where{ $_.name -match 'password' }) {
-        $entry.InnerText = $passkey
+        $entry.InnerText = $KeystoreCredential.Password
     }
 
-    $xml.OuterXml | Set-Content -Path $xmlPath
+    $xml.Save($xmlPath)
 
-    Remove-Item C:\cert.pfx
+    $configPath = "C:\ProgramData\sonatype-work\nexus3\etc\nexus.properties"
 
-    $nexusPath = 'C:\ProgramData\sonatype-work\nexus3'
-    $configPath = "$nexusPath\etc\nexus.properties"
+    # Remove existing ssl config from the configuration
+    (Get-Content $configPath) | Where-Object {$_ -notmatch "application-port-ssl="} | Set-Content $configPath
 
-    $configStrings = @('jetty.https.stsMaxAge=-1', 'application-port-ssl=8443', 'nexus-args=${jetty.etc}/jetty.xml,${jetty.etc}/jetty-https.xml,${jetty.etc}/jetty-requestlog.xml')
-    $configStrings | ForEach-Object {
+    # Ensure each line is added to the configuration
+    @(
+        'jetty.https.stsMaxAge=-1'
+        "application-port-ssl=$Port"
+        'nexus-args=${jetty.etc}/jetty.xml,${jetty.etc}/jetty-https.xml,${jetty.etc}/jetty-requestlog.xml'
+    ) | ForEach-Object {
         if ((Get-Content -Raw $configPath) -notmatch [regex]::Escape($_)) {
             $_ | Add-Content -Path $configPath
         }
     }
-    
+
+    if ((Get-Service Nexus).Status -eq 'Running') {
+        Restart-Service Nexus
+    }
 }
 
 function Test-SelfSignedCertificate {
@@ -1791,11 +1830,13 @@ function Remove-CcmBinding {
 
 function New-CcmBinding {
     [CmdletBinding()]
-    param()
+    param(
+        [string]$Thumbprint
+    )
     Write-Verbose "Adding new binding https://${SubjectWithoutCn} to Chocolatey Central Management"
 
     $guid = [Guid]::NewGuid().ToString("B")
-    netsh http add sslcert ipport=0.0.0.0:443 certhash=$Thumbprint certstorename=MY appid="$guid"
+    netsh http add sslcert ipport=0.0.0.0:443 certhash=$Thumbprint certstorename=TrustedPeople appid="$guid"
     Get-WebBinding -Name ChocolateyCentralManagement | Remove-WebBinding
     New-WebBinding -Name ChocolateyCentralManagement -Protocol https -Port 443 -SslFlags 0 -IpAddress '*'
 }
@@ -2075,12 +2116,18 @@ function Set-JenkinsCertificate {
         # Temporarily export the certificate as a PFX
         $null = Get-ChildItem Cert:\LocalMachine\TrustedPeople\ | Where-Object {$_.Thumbprint -eq $Thumbprint} | Export-PfxCertificate -FilePath $CertificatePath -Password $CertificatePassword.SecurePassword
 
-        Write-Host "Do NOT " -NoNewline  # There is no way to hide the input, but the pipelining works after a second
-        $CurrentAlias = ($($CertificatePassword.Password | & $KeyTool -list -v -storetype PKCS12 -keystore $CertificatePath) -match "^Alias.*").Split(':')[1].Trim()
-        Write-Host ""  # Adds a newline, after this command has finished.
+        # Using a job to hide improper non-output streams
+        $Job = Start-Job {
+            $CurrentAlias = ($($using:CertificatePassword.Password | & $using:KeyTool -list -v -storetype PKCS12 -keystore $using:CertificatePath) -match "^Alias.*").Split(':')[1].Trim()
 
-        $null = & $KeyTool -importkeystore -srckeystore $CertificatePath -srcstoretype PKCS12 -srcstorepass $CertificatePassword.Password -destkeystore $KeyStore -deststoretype JKS -alias $currentAlias -destalias jetty -deststorepass $Passkey
-        $null = & $KeyTool -keypasswd -keystore $KeyStore -alias jetty -storepass $Passkey -keypass $CertificatePassword.Password -new $Passkey
+            $null = & $using:KeyTool -importkeystore -srckeystore $using:CertificatePath -srcstoretype PKCS12 -srcstorepass $using:CertificatePassword.Password -destkeystore $using:KeyStore -deststoretype JKS -alias $currentAlias -destalias jetty -deststorepass $using:Passkey
+            $null = & $using:KeyTool -keypasswd -keystore $using:KeyStore -alias jetty -storepass $using:Passkey -keypass $using:CertificatePassword.Password -new $using:Passkey
+        } | Wait-Job
+        if ($Job.State -eq 'Failed') {
+            $Job | Receive-Job
+        } else {
+            $Job | Remove-Job
+        }
     } finally {
         # Clean up the exported certificate
         Remove-Item $CertificatePath

--- a/scripts/ReadmeTemplate.html.j2
+++ b/scripts/ReadmeTemplate.html.j2
@@ -147,15 +147,6 @@ function CopyToClipboard(id)
   </div>
 </div>
 <div class="main">
-<h2 id="start">Getting Started</h2>
-<ul>
-  <li>Open the <a href="https://{{ ccm_fqdn }}:{{ ccm_port }}">Chocolatey Central Management dashboard</a></li>
-  <li>Login with the credentials named <b>Chocolatey Central Management</b> from the <a href="#accounts">table below</a><br><i>(if javascript is enabled, you can click the password to copy it to your clipboard)</i></li>
-  <li><a href="#connect">Install Chocolatey Agent on another computer</a></li>
-  <li><a href="https://docs.chocolatey.org/en-us/central-management/usage/website/deployments#creating-a-deployment">Create a new deployment</a>, or import <a href="https://ch0.co/deployment-templates">example deployments</a>.</li>
-  <li><a href="https://{{ jenkins_fqdn }}:{{ jenkins_port }}/job/Internalize%20packages%20from%20the%20Chocolatey%20Community%20and%20Licensed%20Repositories/build?delay=0sec">Internalize some new packages</a> with Jenkins</li>
-</ul>
-<h2 id="accounts">Accounts and Secrets</h2>
 <table>
     <colgroup><col/><col/><col/><col/><col/><col/></colgroup>
     <tr><th/><th>Name</th><th>Url</th><th>Username</th><th>Password</th><th>ApiKey</th></tr>
@@ -205,28 +196,6 @@ function CopyToClipboard(id)
 <div style="margin-left: 2rem;">
 <p>The tables above provides credentials to login to each of the services made available as part of the deployment.</p>
 <p>Ensure you change them, store your new credentials and secrets in a secure manner, and delete the stored files.</p>
-</p></div></blockquote>
-
-<h2 id="connect">Adding Computers to Chocolatey Central Management</h2>
-<p>To connect a computer to the Chocolatey Central Management instance, you can use Ansible:</p>
-<pre><code>
-- name: Connect to Chocolatey Central Management
-  win_chocolateyagent:
-    ccm_hostname: {{ ccm_fqdn }}
-    client_salt: {{ ccm_client_salt | default('') | e }}
-    service_salt: {{ ccm_service_salt | default('') | e }}
-    repository:
-      - name: ChocolateyInternal
-        url: https://{{ nexus_fqdn }}:{{ nexus_port }}/repository/ChocolateyInternal/index.json
-        username: chocouser
-        password: {{ chocouser_password | e }}
-</code></pre>
-<p>You can use PowerShell:</p>
-<pre><code>
-  $Credential = [PSCredential]::new("chocouser", (ConvertTo-SecureString '{{ chocouser_password | e }}' -AsPlainText -Force))
-  Invoke-WebRequest https://{{ nexus_fqdn }}:{{ nexus_port }}/repository/choco-install/ClientSetup.ps1 -OutFile $env:Temp\ClientSetup.ps1 -Credential $Credential
-  $env:Temp\ClientSetup.ps1 -Credential $Credential -ClientSalt '{{ ccm_client_salt | default('') | e }}' -ServerSalt '{{ ccm_service_salt | default('') | e }}'
-</code></pre>
-</div>
+</div></blockquote>
 </body>
 </html>

--- a/tests/ccm.tests.ps1
+++ b/tests/ccm.tests.ps1
@@ -8,21 +8,18 @@ Param(
 Describe "Chocolatey Central Management Configuration" {
     Context "Services" {
         BeforeAll {
+            $expectedCertificate = Get-ChildItem Cert:\LocalMachine\TrustedPeople | Where-Object { "CN=$Fqdn" -like $_.Subject }
             $centralManagementServiceCertificate = Get-RemoteCertificate -Computername $Fqdn -Port 24020
-            $expectedServiceCertificate = Get-ChildItem Cert:\LocalMachine\TrustedPeople | Where-Object { "CN=$Fqdn" -like $_.Subject }
-
             $centralManagementWebCertificate = Get-RemoteCertificate -ComputerName $Fqdn -Port 443
-            $expectedWebCertificate = Get-ChildItem Cert:\LocalMachine\My | Where-Object { "CN=$Fqdn" -like $_.Subject }
 
             $centralManagementFirewallRule = (Get-NetFirewallRule -DisplayName Choco*)
 
-            $CCMService = try { 
+            $CCMService = try {
                 ([System.Net.WebRequest]::Create("https://$($Fqdn):24020/ChocolateyManagementService") -as [System.net.HttpWebRequest]).GetResponse().StatusCode 
-            } 
-            catch { 
+            }
+            catch {
                 $_.Exception.Message -match '400'
-            } 
-
+            }
         }
 
         It "Website is listening on port 443" {
@@ -32,10 +29,10 @@ Describe "Chocolatey Central Management Configuration" {
             $CCMService | Should -Be $true       
         }
         It "Web interface is using correct SSL Certificate" {
-            $centralManagementWebCertificate -eq $expectedWebCertificate | Should -Be $true
+            $centralManagementWebCertificate | Should -Be $expectedCertificate
         }
         It "Central Management service is using correct SSL Certificate" {
-            $centralManagementServiceCertificate -eq $expectedServiceCertificate | Should -Be $true
+            $centralManagementServiceCertificate | Should -Be $expectedCertificate
         }
         It "Firewall rule for Central Management Service exists" {
             $centralManagementFirewallRule | Should -Not -BeNullOrEmpty

--- a/tests/jenkins.tests.ps1
+++ b/tests/jenkins.tests.ps1
@@ -8,7 +8,7 @@ Param(
 Describe "Jenkins Configuration" {
     Context "Installation Integrity" {
         BeforeAll {
-            $jenkins = choco.exe list -r | ConvertFrom-Csv -Delimiter '|' -Header Package,Version | Where-Object Package -eq 'jenkins'
+            $jenkins = C:\ProgramData\chocolatey\choco.exe list -r | ConvertFrom-Csv -Delimiter '|' -Header Package,Version | Where-Object Package -eq 'jenkins'
             $service = Get-Service jenkins
         }
 

--- a/tests/nexus.tests.ps1
+++ b/tests/nexus.tests.ps1
@@ -10,7 +10,7 @@ Param(
 Describe "Nexus Configuration" {
     Context "Installation Integrity" {
         BeforeAll {
-            $nexus = choco.exe list -r | ConvertFrom-Csv -Delimiter '|' -Header Package,Version | Where-Object Package -eq nexus-repository
+            $nexus = C:\ProgramData\chocolatey\choco.exe list -r | ConvertFrom-Csv -Delimiter '|' -Header Package, Version | Where-Object Package -EQ nexus-repository
             $service = Get-Service nexus
         }
 
@@ -32,36 +32,18 @@ Describe "Nexus Configuration" {
             $serviceCertificate = Get-RemoteCertificate -ComputerName $Fqdn -Port 8443
 
             $ConfigurationFile = Get-Content "C:\ProgramData\sonatype-work\nexus3\etc\nexus.properties"
-            $expectedConfiguation = @'
-# Jetty section
-# application-port=8081
-# application-host=0.0.0.0
-# nexus-args=${jetty.etc}/jetty.xml,${jetty.etc}/jetty-http.xml,${jetty.etc}/jetty-requestlog.xml
-# nexus-context-path=/
-
-# Nexus section
-# nexus-edition=nexus-pro-edition
-# nexus-features=\
-#  nexus-pro-feature
-
-# nexus.hazelcast.discovery.isEnabled=true
-jetty.https.stsMaxAge=-1
-application-port-ssl=8443
-nexus-args=${jetty.etc}/jetty.xml,${jetty.etc}/jetty-https.xml,${jetty.etc}/jetty-requestlog.xml
-
-'@
         }
 
         It "Service has HSTS disabled" {
-            $ConfigurationFile[12] -eq 'jetty.https.stsMaxAge=-1' | Should -Be $true
+            $ConfigurationFile -contains 'jetty.https.stsMaxAge=-1' | Should -Be $true
         }
 
         It "Service is using port 8443" {
-            $ConfigurationFile[13] -eq 'application-port-ssl=8443' | Should -Be $true
+            $ConfigurationFile -contains 'application-port-ssl=8443' | Should -Be $true
         }
 
         It "Service is using jetty-https.xml" {
-            $ConfigurationFile[14] -eq 'nexus-args=${jetty.etc}/jetty.xml,${jetty.etc}/jetty-https.xml,${jetty.etc}/jetty-requestlog.xml' | Should -Be $true
+            $ConfigurationFile -contains 'nexus-args=${jetty.etc}/jetty.xml,${jetty.etc}/jetty-https.xml,${jetty.etc}/jetty-requestlog.xml' | Should -Be $true
         }
 
         It "Service is using the appropriate SSL Certificate" {
@@ -101,11 +83,11 @@ nexus-args=${jetty.etc}/jetty.xml,${jetty.etc}/jetty-https.xml,${jetty.etc}/jett
 
     Context "Package Availability" {
         BeforeAll {
-            if (([version] (choco.exe --version).Split('-')[0]) -ge [version] '2.1.0') {
+            if (([version] (C:\ProgramData\chocolatey\choco.exe --version).Split('-')[0]) -ge [version] '2.1.0') {
                 choco cache remove
             }
 
-            $packages = choco.exe search -s ChocolateyInternal -r | ConvertFrom-Csv -Delimiter '|' -Header Package,Version
+            $packages = C:\ProgramData\chocolatey\choco.exe search -s ChocolateyInternal -r | ConvertFrom-Csv -Delimiter '|' -Header Package, Version
         }
 
         It "<Name> is in the repository" -ForEach @( $JointPackages + $RepositoryOnlyPackages ) {

--- a/tests/packages.ps1
+++ b/tests/packages.ps1
@@ -20,7 +20,6 @@ $ServerOnlyPackages = @(
     @{Name = 'KB3033929' }
     @{Name = 'KB3035131' }
     @{Name = 'KB3063858' }
-    @{Name = 'microsoft-edge' }
     @{Name = 'nexus-repository' }
     @{Name = 'Pester' }
     @{Name = 'sql-server-express' }

--- a/tests/server.tests.ps1
+++ b/tests/server.tests.ps1
@@ -2,7 +2,7 @@
 Describe "Server Integrity" {
     Context "Required Packages" {
         BeforeAll {
-            $packages = choco.exe list -r | ConvertFrom-Csv -Delimiter '|' -Header Package, Version
+            $packages = C:\ProgramData\chocolatey\choco.exe list -r | ConvertFrom-Csv -Delimiter '|' -Header Package, Version
         }
 
         It "<Name> is installed"  -Foreach @( $JointPackages + $ServerOnlyPackages ) {


### PR DESCRIPTION
## Description Of Changes
- Removed Ansible code from connect section of README
- Change Internalize some new packages link to point to correct name of Jenkins jobs

## Motivation and Context
No need for Ansible callout as we have a separate enviornment for Ansible users.

## Testing
1. Local VM QSG build

### Operating Systems Testing
- Windows Server 2022

## Change Types Made
* ~[ ] Bug fix (non-breaking change).~
* [X] Feature / Enhancement (non-breaking change).
* ~[ ] Breaking change (fix or feature that could cause existing functionality to change).~
* ~[ ] Documentation changes.~
* ~[ ] PowerShell code changes.~

## Change Checklist
* ~[ ] Requires a change to the documentation.~
* ~[ ] Documentation has been updated.~
* ~[ ] Tests to cover my changes, have been added.~
* ~[ ] All new and existing tests passed?~
* ~[ ] PowerShell code changes: PowerShell v3 compatibility checked?~

## Related Issue
Fixes #263
