### PR TITLE
(#266) Updates Version Lookup in ClientSetup Script

### DIFF
--- a/scripts/ClientSetup.ps1
+++ b/scripts/ClientSetup.ps1
@@ -84,15 +84,12 @@ if ($Credential) {
 
 # Find the latest version of Chocolatey, if a version was not specified
 $NupkgUrl = if (-not $ChocolateyVersion) {
-    $QueryString = "((Id eq 'chocolatey') and (not IsPrerelease)) and IsLatestVersion"
-    $Query = 'Packages()?$filter={0}' -f [uri]::EscapeUriString($queryString)
-    $QueryUrl = ($RepositoryUrl.TrimEnd('/index.json'), $Query) -join '/'
-
-    [xml]$result = $webClient.DownloadString($QueryUrl)
-    $result.feed.entry.content.src
+    $QueryUrl = ($RepositoryUrl.TrimEnd('/index.json'), "v3/registration/Chocolatey/index.json") -join '/'
+    $Result = $webClient.DownloadString($QueryUrl) | ConvertFrom-Json
+    $Result.items.items[-1].packageContent
 } else {
     # Otherwise, assume the URL
-    "$($RepositoryUrl.TrimEnd('/index.json'))/chocolatey/$($ChocolateyVersion)"
+    "$($RepositoryUrl.TrimEnd('/index.json'))/v3/content/chocolatey/$($ChocolateyVersion)/chocolatey.$($ChocolateyVersion).nupkg"
 }
 
 # Download the NUPKG


### PR DESCRIPTION
## Description Of Changes
This commit changes the lookup to something that works on the post-3.71 available calls.

Though the v2-style assumed URL works currently, I have updated it to match the format returned by the index, as I can't speak for if Nexus will remove that.

## Motivation and Context
The recent changes to Nexus cause the v2 lookup to no longer work correctly.

## Testing
1. Tested against a v3.71 instance of Nexus

### Operating Systems Testing
- Windows Server 2022 (Nexus), Windows 11 Sandbox (registering client)

## Change Types Made

* [x] Bug fix (non-breaking change).
* ~[ ] Feature / Enhancement (non-breaking change).~
* ~[ ] Breaking change (fix or feature that could cause existing functionality to change).~
* ~[ ] Documentation changes.~
* [x] PowerShell code changes.

## Change Checklist

* ~[ ] Requires a change to the documentation.~
* ~[ ] Documentation has been updated.~
* ~[ ] Tests to cover my changes, have been added.~
* ~[ ] All new and existing tests passed?~
* ~[ ] PowerShell code changes: PowerShell v3 compatibility checked?~

## Related Issue

Fixes #266
