### PR TITLE
(build) Allows External Forks to Target Builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,10 @@ on:
         description: The configurations to test with.
         default: self-signed, single, wildcard
 
-  pull_request:
-    paths:
-      - files/**.json
-      - "**.ps1"
-      - scripts/**.ps1
+  pull_request_target:
+    paths-ignore:
+      - .github/workflows/**
+
     types:
       - opened
       - reopened
@@ -361,7 +360,7 @@ jobs:
     name: Cleanup Test Resources
     runs-on: ubuntu-latest
     needs: [build, runner_test_deploy]
-    if: success() || failure()
+    if: always()
     steps:
       - name: Login to Azure
         uses: azure/login@v2
@@ -383,12 +382,12 @@ jobs:
                   "X-GitHub-Api-Version" = "2022-11-28"
                 }
               }
-              Invoke-RestMethod @DeleteArgs
+              Invoke-RestMethod @DeleteArgs -ErrorAction SilentlyContinue
             }
 
             $ResourceGroupName = "qsg-testing"
             if ('${{ github.run_id }}' -ne "`$`{{ github.run_id }}") {$ResourceGroupName += '-${{ github.run_id }}'}
             if (Get-AzResourceGroup -ResourceGroupName $ResourceGroupName -ErrorAction SilentlyContinue) {
-              Remove-AzResourceGroup -ResourceGroupName $ResourceGroupName -Force  # -AsJob
+              Remove-AzResourceGroup -ResourceGroupName $ResourceGroupName -Force
             }
           azPSVersion: latest


### PR DESCRIPTION
## Description Of Changes

Allows forks to trigger the build using repository secrets.

Does not trigger a build if the workflows are changed. If the workflows are changed, a maintainer will have to manually trigger a build.

## Motivation and Context

Folk may submit changes from forks.

## Testing


### Operating Systems Testing

## Change Types Made

* ~[ ] Bug fix (non-breaking change).~
* [x] Feature / Enhancement (non-breaking change).
* ~[ ] Breaking change (fix or feature that could cause existing functionality to change).~
* ~[ ] Documentation changes.~
* ~[ ] PowerShell code changes.~

## Change Checklist

* ~[ ] Requires a change to the documentation.~
* ~[ ] Documentation has been updated.~
* ~[ ] Tests to cover my changes, have been added.~
* ~[ ] All new and existing tests passed?~
* ~[ ] PowerShell code changes: PowerShell v3 compatibility checked?~
