### PR TITLE
(#258) Updates KeyTool to Force English Language Output

### DIFF
--- a/scripts/Get-Helpers.ps1
+++ b/scripts/Get-Helpers.ps1
@@ -1675,7 +1675,7 @@ function Set-NexusCert {
 
         # Using a job to hide improper non-output streams
         $Job = Start-Job {
-            $string = ($using:KeystoreCredential.Password | & $using:KeyTool -list -v -keystore $using:TempCertPath) -match '^Alias.*'
+            $string = ($using:KeystoreCredential.Password | & $using:KeyTool -list -v -keystore $using:TempCertPath -J"-Duser.language=en") -match '^Alias.*'
             $currentAlias = ($string -split ':')[1].Trim()
             & $using:KeyTool -importkeystore -srckeystore $using:TempCertPath -srcstoretype PKCS12 -srcstorepass $using:KeystoreCredential.Password -destkeystore $using:KeyStorePath -deststoretype JKS -alias $currentAlias -destalias jetty -deststorepass $using:KeystoreCredential.Password
             & $using:KeyTool -keypasswd -keystore $using:KeyStorePath -alias jetty -storepass $using:KeystoreCredential.Password -keypass $using:KeystoreCredential.Password -new $using:KeystoreCredential.Password
@@ -2095,7 +2095,7 @@ function Set-JenkinsCertificate {
     )
 
     $KeyStore = "C:\ProgramData\Jenkins\.jenkins\keystore.jks"
-    $KeyTool = Convert-Path "C:\Program Files\Eclipse Adoptium\jre-*.*\bin\keytool.exe"  # Using Temurin11jre package keytool
+    $KeyTool = Convert-Path "C:\Program Files\Eclipse Adoptium\jre-*.*\bin\keytool.exe"  # Using Temurin jre package keytool
     $Passkey = [System.Net.NetworkCredential]::new(
         "JksPassword",
         (New-ServicePassword -AvailableCharacters @(48..57 + 65..90 + 97..122))
@@ -2118,7 +2118,7 @@ function Set-JenkinsCertificate {
 
         # Using a job to hide improper non-output streams
         $Job = Start-Job {
-            $CurrentAlias = ($($using:CertificatePassword.Password | & $using:KeyTool -list -v -storetype PKCS12 -keystore $using:CertificatePath) -match "^Alias.*").Split(':')[1].Trim()
+            $CurrentAlias = ($($using:CertificatePassword.Password | & $using:KeyTool -list -v -storetype PKCS12 -keystore $using:CertificatePath -J"-Duser.language=en") -match "^Alias.*").Split(':')[1].Trim()
 
             $null = & $using:KeyTool -importkeystore -srckeystore $using:CertificatePath -srcstoretype PKCS12 -srcstorepass $using:CertificatePassword.Password -destkeystore $using:KeyStore -deststoretype JKS -alias $currentAlias -destalias jetty -deststorepass $using:Passkey
             $null = & $using:KeyTool -keypasswd -keystore $using:KeyStore -alias jetty -storepass $using:Passkey -keypass $using:CertificatePassword.Password -new $using:Passkey

--- a/scripts/Set-NexusCert.ps1
+++ b/scripts/Set-NexusCert.ps1
@@ -50,7 +50,7 @@ Write-Host "Exporting .pfx file to C:\, will remove when finished" -ForegroundCo
 $certificate | Export-PfxCertificate -FilePath C:\cert.pfx -Password $password
 Get-ChildItem -Path c:\cert.pfx | Import-PfxCertificate -CertStoreLocation Cert:\LocalMachine\My -Exportable -Password $password
 Write-Warning -Message "You'll now see prompts and other outputs, things are working as expected, don't do anything"
-$string = ("chocolatey" | & $KeyTool -list -v -keystore C:\cert.pfx) -match '^Alias.*'
+$string = ("chocolatey" | & $KeyTool -list -v -keystore C:\cert.pfx -J"-Duser.language=en") -match '^Alias.*'
 $currentAlias = ($string -split ':')[1].Trim()
 
 $passkey = '9hPRGDmfYE3bGyBZCer6AUsh4RTZXbkw'


### PR DESCRIPTION
## Description Of Changes
This commit forces KeyTool, when called for matching the output, to output in English.

## Motivation and Context
Customers on non-English installations of Windows had issues where our regex wouldn't match their localized output.

## Testing


### Operating Systems Testing

- Windows Server 2022
- Windows Server 2019

## Change Types Made

* [x] Bug fix (non-breaking change).
* ~[ ] Feature / Enhancement (non-breaking change).~
* ~[ ] Breaking change (fix or feature that could cause existing functionality to change).~
* ~[ ] Documentation changes.~
* [x] PowerShell code changes.

## Change Checklist

* ~[ ] Requires a change to the documentation.~
* ~[ ] Documentation has been updated.~
* ~[ ] Tests to cover my changes, have been added.~
* [ ] All new and existing tests passed?
* [x] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #258
