### PR TITLE
(#261) Remove LocalChocolateySetup Source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -322,7 +322,7 @@ jobs:
               $TestResults = Invoke-Command -Session $Session -ScriptBlock {
                 if (-not (Get-Module Pester -ListAvailable).Where{$_.Version -gt "5.0"}) {
                   Write-Host "Installing Pester 5 to run validation tests"
-                  $chocoArgs = @('install', 'pester', '-y', '--source="https://community.chocolatey.org/api/v2/"')
+                  $chocoArgs = @('install', 'pester', '-y', '--source="ChocolateyInternal"', '--no-progress')
                   & choco @chocoArgs | Write-Host
                 }
                 (Get-ChildItem C:\choco-setup\files\tests\ -Recurse -Filter *.tests.ps1).Fullname

--- a/Set-SslSecurity.ps1
+++ b/Set-SslSecurity.ps1
@@ -295,6 +295,7 @@ process {
             CentralManagementServiceUrl = "https://$($SubjectWithoutCn):24020/ChocolateyManagementService"
             ServiceSalt = $ServiceSaltValue
             ClientSalt = $ClientSaltValue
+            Source = "ChocolateyInternal"
         }
 
         Install-ChocolateyAgent @agentArgs
@@ -302,6 +303,7 @@ process {
         # Agent Setup
         $agentArgs = @{
             CentralManagementServiceUrl = "https://$($SubjectWithoutCn):24020/ChocolateyManagementService"
+            Source = "ChocolateyInternal"
         }
 
         Install-ChocolateyAgent @agentArgs

--- a/Start-C4bCcmSetup.ps1
+++ b/Start-C4bCcmSetup.ps1
@@ -33,7 +33,7 @@ process {
 
     # DB Setup
     Write-Host "Installing SQL Server Express"
-    $chocoArgs = @('upgrade', 'sql-server-express', '-y', '--no-progress')
+    $chocoArgs = @('upgrade', 'sql-server-express', "--source='ChocolateyInternal'", '-y', '--no-progress')
     & Invoke-Choco @chocoArgs
 
     # https://docs.microsoft.com/en-us/sql/tools/configuration-manager/tcp-ip-properties-ip-addresses-tab
@@ -95,17 +95,17 @@ process {
     $chocoArgs = @('install', 'IIS-ApplicationInit', "--source='windowsfeatures'" ,'--no-progress', '-y')
     & Invoke-Choco @chocoArgs -ValidExitCodes 0, 3010
 
-    $chocoArgs = @('install', 'dotnet-aspnetcoremodule-v2', "--version='$($Packages.Where{$_.Name -eq 'dotnet-aspnetcoremodule-v2'}.Version)'", '--no-progress', '-y')
+    $chocoArgs = @('install', 'dotnet-aspnetcoremodule-v2', "--source='ChocolateyInternal'", "--version='$($Packages.Where{$_.Name -eq 'dotnet-aspnetcoremodule-v2'}.Version)'", '--no-progress', '-y')
     & Invoke-Choco @chocoArgs
 
-    $chocoArgs = @('install', 'dotnet-8.0-runtime', "--version=$($Packages.Where{$_.Name -eq 'dotnet-8.0-runtime'}.Version)", '--no-progress', '-y')
+    $chocoArgs = @('install', 'dotnet-8.0-runtime', "--source='ChocolateyInternal'", "--version=$($Packages.Where{$_.Name -eq 'dotnet-8.0-runtime'}.Version)", '--no-progress', '-y')
     & Invoke-Choco @chocoArgs
 
-    $chocoArgs = @('install', 'dotnet-8.0-aspnetruntime', "--version=$($Packages.Where{$_.Name -eq 'dotnet-8.0-aspnetruntime'}.Version)", '--no-progress', '-y')
+    $chocoArgs = @('install', 'dotnet-8.0-aspnetruntime', "--source='ChocolateyInternal'", "--version=$($Packages.Where{$_.Name -eq 'dotnet-8.0-aspnetruntime'}.Version)", '--no-progress', '-y')
     & Invoke-Choco @chocoArgs
 
     Write-Host "Creating Chocolatey Central Management Database"
-    choco install chocolatey-management-database -y --package-parameters="'/ConnectionString=Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;Trusted_Connection=true;'" --no-progress
+    choco install chocolatey-management-database --source='ChocolateyInternal' -y --package-parameters="'/ConnectionString=Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;Trusted_Connection=true;'" --no-progress
 
     # Add Local Windows User:
     $DatabaseUser = $DatabaseCredential.UserName
@@ -138,12 +138,12 @@ process {
     }
 
     else {
-        $chocoArgs = @('install', 'chocolatey-management-service', '-y', "--package-parameters-sensitive=`"/ConnectionString:'Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;User ID=$DatabaseUser;Password=$DatabaseUserPw;'`"", '--no-progress')
+        $chocoArgs = @('install', 'chocolatey-management-service', "--source='ChocolateyInternal'", '-y', "--package-parameters-sensitive=`"/ConnectionString:'Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;User ID=$DatabaseUser;Password=$DatabaseUserPw;'`"", '--no-progress')
         & Invoke-Choco @chocoArgs
     }
 
     Write-Host "Installing Chocolatey Central Management Website"
-    $chocoArgs = @('install', 'chocolatey-management-web', '-y', "--package-parameters-sensitive=""'/ConnectionString:Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;User ID=$DatabaseUser;Password=$DatabaseUserPw;'""", '--no-progress')
+    $chocoArgs = @('install', 'chocolatey-management-web', "--source='ChocolateyInternal'", '-y', "--package-parameters-sensitive=""'/ConnectionString:Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;User ID=$DatabaseUser;Password=$DatabaseUserPw;'""", '--no-progress')
     & Invoke-Choco @chocoArgs
 
     $CcmSvcUrl = Invoke-Choco config get centralManagementServiceUrl -r

--- a/Start-C4bJenkinsSetup.ps1
+++ b/Start-C4bJenkinsSetup.ps1
@@ -26,7 +26,7 @@ process {
     Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Start-C4bJenkinsSetup-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
 
     # Install temurin21jre to meet JRE>11 dependency of Jenkins
-    $chocoArgs = @('install', 'temurin21jre', '-y', '--no-progress', "--params='/ADDLOCAL=FeatureJavaHome'")
+    $chocoArgs = @('install', 'temurin21jre', "--source='ChocolateyInternal'", '-y', '--no-progress', "--params='/ADDLOCAL=FeatureJavaHome'")
     & Invoke-Choco @chocoArgs
 
     # Environment variable used to disable jenkins install login prompts
@@ -34,7 +34,7 @@ process {
 
     # Install Jenkins
     Write-Host "Installing Jenkins"
-    $chocoArgs = @('install', 'jenkins', '-y', '--no-progress')
+    $chocoArgs = @('install', 'jenkins', "--source='ChocolateyInternal'", '-y', '--no-progress')
     & Invoke-Choco @chocoArgs
 
     Write-Host "Giving Jenkins 30 seconds to complete background setup..." -ForegroundColor Green

--- a/Start-C4bNexusSetup.ps1
+++ b/Start-C4bNexusSetup.ps1
@@ -84,6 +84,10 @@ process {
     # Add ChocolateyInternal as a source repository
     Invoke-Choco source add -n 'ChocolateyInternal' -s "$((Get-NexusRepository -Name 'ChocolateyInternal').url)/index.json" --priority 1
 
+    #Remove Local Chocolatey Setup Source
+    $chocoArgs = @('source', 'remove', '--name="LocalChocolateySetup"')
+    & Invoke-Choco @chocoArgs
+    
     # Install a non-IE browser for browsing the Nexus web portal.
     if (-not (Test-Path 'C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe')) {
         Write-Host "Installing Microsoft Edge, to allow viewing the Nexus site"

--- a/Start-C4bVerification.ps1
+++ b/Start-C4bVerification.ps1
@@ -8,7 +8,7 @@ Param(
 process {
     if (-not (Get-Module Pester -ListAvailable).Where{$_.Version -gt "5.0"}) {
         Write-Host "Installing Pester 5 to run validation tests"
-        $chocoArgs = @('install', 'pester', '-y', '--no-progress', '--source="https://community.chocolatey.org/api/v2/"')
+        $chocoArgs = @('install', 'pester', "--source='ChocolateyInternal'", '-y', '--no-progress', '--source="https://community.chocolatey.org/api/v2/"')
         & Invoke-Choco @chocoArgs
     }
 

--- a/files/chocolatey.json
+++ b/files/chocolatey.json
@@ -24,6 +24,7 @@
         { "name": "KB3035131", "internalize": false },
         { "name": "microsoft-edge" },
         { "name": "nexus-repository" },
+        { "name": "pester" },
         { "name": "sql-server-express" },
         { "name": "temurin21jre" },
         { "name": "vcredist140" }

--- a/tests/server.tests.ps1
+++ b/tests/server.tests.ps1
@@ -1,5 +1,19 @@
 . $PSScriptRoot/packages.ps1
 Describe "Server Integrity" {
+    Context "Chocolatey Sources" {
+        BeforeAll {
+            $sources = C:\ProgramData\chocolatey\choco.exe source list -r | ConvertFrom-Csv -Delimiter '|' -Header Name, Url, Disabled, Username, Password, Priority, BypassProxy, SelfService, AdminOnly
+        }
+
+        It "LocalChocolateySetup source was removed" {
+            "LocalChocolateySetup" -in $sources.Name | Should -BeFalse
+        }
+
+        It "ChocolateyInternal source exists" {
+            "ChocolateyInternal" -in $sources.Name | Should -Be $true
+        }
+    }
+
     Context "Required Packages" {
         BeforeAll {
             $packages = C:\ProgramData\chocolatey\choco.exe list -r | ConvertFrom-Csv -Delimiter '|' -Header Package, Version


### PR DESCRIPTION
## Description Of Changes
- Remove the LocalChocolateySetup source from the server
- Add Chocolatey Sources Testing section to allow further source testing in the future.
- Add a test to check if the LocalChocolateySetup source is removed
- Add a test to check if the ChocolateyInternal source exists
- Add Pester package to manifest
- Source all package installs past Nexus Setup from the Nexus repository.

## Motivation and Context
Remove a source that is no longer needed after all packages have been pushed to the repo and all steps have run the source packages. 

Add tests for changes made.

## Testing
1. Local VM testing
2. Automated testing

### Operating Systems Testing
- Windows Server 2019
- Windows Server 2022

## Change Types Made
* ~[ ] Bug fix (non-breaking change).~
* [X] Feature / Enhancement (non-breaking change).
* ~[ ] Breaking change (fix or feature that could cause existing functionality to change).~
* ~[ ] Documentation changes.~
* [X] PowerShell code changes.

## Change Checklist
* ~[ ] Requires a change to the documentation.~
* ~[ ] Documentation has been updated.~
* [X] Tests to cover my changes have been added.
* [X] All new and existing tests passed?

## Related Issue
Fixes #261 
