### PR TITLE
(fix) ModulesDir blank when invoked as quicklink

### DIFF
--- a/Start-C4bSetup.ps1
+++ b/Start-C4bSetup.ps1
@@ -121,8 +121,8 @@ try {
 
     # Add the Module Path and Import Helper Functions
     if (-not (Get-Module C4B-Environment -ListAvailable)) {
-        if ($env:PSModulePath.Split(';') -notcontains "$PSScriptRoot\modules") {
-            [Environment]::SetEnvironmentVariable("PSModulePath", "$env:PSModulePath;$PSScriptRoot\modules" ,"Machine")
+        if ($env:PSModulePath.Split(';') -notcontains "$FilesDir\modules") {
+            [Environment]::SetEnvironmentVariable("PSModulePath", "$env:PSModulePath;$FilesDir\modules" ,"Machine")
             $env:PSModulePath = [Environment]::GetEnvironmentVariables("Machine").PSModulePath
         }
     }


### PR DESCRIPTION
## Description Of Changes
Fixes a usage of PSScriptRoot in the initializing script.

## Motivation and Context
The script was failing to run when it hadn't been run from disk, e.g. when using the `irm qsg-go | iex` method. This wasn't caught by the tests because we download and run it from disk in those scripts, but we often enjoy using the easier to remember method above.

## Testing
1. Tested on a local Windows Server 2022 VM by running with the raw URL from my branch, rather than the short link.

### Operating Systems Testing
- Windows 2022

## Change Types Made

* [x] Bug fix (non-breaking change).
* ~[ ] Feature / Enhancement (non-breaking change).~
* ~[ ] Breaking change (fix or feature that could cause existing functionality to change).~
* ~[ ] Documentation changes.~
* [x] PowerShell code changes.

## Change Checklist

* ~[ ] Requires a change to the documentation.~
* ~[ ] Documentation has been updated.~
* ~[ ] Tests to cover my changes, have been added.~
* [x] All new and existing tests passed?
* [x] PowerShell code changes: PowerShell v3 compatibility checked?