### PR TITLE
(#153) Enable FIPs if required

### DIFF
--- a/OfflineInstallPreparation.ps1
+++ b/OfflineInstallPreparation.ps1
@@ -60,8 +60,6 @@ $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 $LicensePath = Convert-Path $LicensePath
 
-Import-Module $PSScriptRoot\modules\C4B-Environment
-
 $ChocoInstallScript = Join-Path $PSScriptRoot "scripts\ChocolateyInstall.ps1"
 if (-not (Test-Path $ChocoInstallScript)) {
     Invoke-WebRequest -Uri 'https://chocolatey.org/install.ps1' -OutFile $ChocoInstallScript
@@ -79,6 +77,8 @@ if ($Signature.Status -eq 'Valid' -and $Signature.SignerCertificate.Subject -eq 
 } else {
     Write-Error "ChocolateyInstall.ps1 script signature is not valid. Please investigate." -ErrorAction Stop
 }
+
+Import-Module $PSScriptRoot\modules\C4B-Environment -Force
 
 # Initialize environment, ensure Chocolatey For Business, etc.
 $Licensed = ($($(choco.exe)[0] -match "^Chocolatey (?<Version>\S+)\s*(?<LicenseType>Business)?$") -and $Matches.LicenseType)

--- a/files/chocolatey.json
+++ b/files/chocolatey.json
@@ -24,7 +24,7 @@
         { "name": "KB3035131", "internalize": false },
         { "name": "microsoft-edge" },
         { "name": "nexus-repository" },
-        { "name": "pester" },
+        { "name": "pester", "internalize": false },
         { "name": "sql-server-express" },
         { "name": "temurin21jre" },
         { "name": "vcredist140" }

--- a/modules/C4B-Environment/C4B-Environment.psm1
+++ b/modules/C4B-Environment/C4B-Environment.psm1
@@ -2319,4 +2319,14 @@ function Install-ChocolateyAgent {
 }
 #endregion
 
+# Check for and configure FIPS enforcement, if required.
+if (
+    (Get-ItemPropertyValue -Path "HKLM:\System\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy" -Name Enabled) -eq 1 -and
+    $env:ChocolateyInstall -and
+    -not [bool]::Parse(([xml](Get-Content $env:ChocolateyInstall\config\chocolatey.config)).chocolatey.features.feature.Where{$_.Name -eq 'useFipsCompliantChecksums'}.Enabled)
+) {
+    Write-Warning -Message "FIPS is enabled on this system. Ensuring Chocolatey uses FIPS compliant checksums"
+    Invoke-Choco feature enable --name='useFipsCompliantChecksums'
+}
+
 Export-ModuleMember -Function "*"

--- a/scripts/ClientSetup.ps1
+++ b/scripts/ClientSetup.ps1
@@ -105,6 +105,13 @@ $script = $webClient.DownloadString("https://${hostAddress}/repository/choco-ins
 # Run the Chocolatey Install script with the parameters provided
 & ([scriptblock]::Create($script)) @params
 
+# If FIPS is enabled, configure Chocolatey to use FIPS compliant checksums
+$fipsStatus = Get-ItemProperty -Path "HKLM:\System\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy" -Name Enabled
+if ($fipsStatus.Enabled -eq 1) {
+    Write-Warning -Message "FIPS is enabled on this system. Ensuring Chocolatey uses FIPS compliant checksums"
+    choco feature enable --name='useFipsCompliantChecksums'
+}
+
 choco config set cacheLocation $env:ChocolateyInstall\choco-cache
 choco config set commandExecutionTimeoutSeconds 14400
 


### PR DESCRIPTION
If we detect that FIPs is enabled on a system when we
install Chocolatey, we should also configure Chocolatey
to use FIPs-compliant checksums. Without enabling this
feature, package installations will fail as Chocolatey
will not use a compliant hashing mechanism.

## Description Of Changes

This change adds detection for FIPs and sets Chocolatey configuration to use FIPS compliant checksums if FIPs is detected to be enabled

## Motivation and Context

When FIPs is enabled, Chocolatey does not use a checksum mechanism that is strong enough to meet the requirements of FIPs security.

## Testing

Tested locally in AutomatedLab and confirmed when FIPs is enabled, chocolatey configures FIPs compliant checksums.

### Operating Systems Testing

Server 2022

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [x] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #153 