### PR TITLE
(#105) Removes "Hardened" Option, Always Secures

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,26 +181,26 @@ Below are the minimum requirements for setting up your C4B server via this guide
 
     ```powershell
     Set-Location "$env:SystemDrive\choco-setup\files"
-    .\Set-SslSecurity.ps1 -Thumbprint '<YOUR_CUSTOM_SSL_CERT_THUMBPRINT_HERE>' -Hardened
+    .\Set-SslSecurity.ps1 -Thumbprint '<YOUR_CUSTOM_SSL_CERT_THUMBPRINT_HERE>'
     ```
 
     > :warning:**REMINDER**: If you are using your own SSL certificate, be sure to place this certificate in the `Local Machine > Personal` certificate store before running the above script, and ensure that the private key is exportable.
 
     > :memo: **NOTE**
-    > You may have noticed the `-Hardened` parameter we've added above. When using a custom SSL certificate, this parameter will further secure access to your C4B Server. A Role and User credential will be configured to limit access to your Nexus repositories. As well, CCM Client and Service Salts are configured to further encrypt your connection between CCM and your endpoint clients. These additional settings are also incorporated into your `Register-C4bEndpoint.ps1` script for onboarding endpoints. We do require you to enable this option if your C4B Server will be Internet-facing, with a FQDN that resolves to a public IP.
+    > A Role and User credential will be configured to limit access to your Nexus repositories. As well, CCM Client and Service Salts are configured to further encrypt your connection between CCM and your endpoint clients. These additional settings are also incorporated into your `Register-C4bEndpoint.ps1` script for onboarding endpoints.
 
     **ALTERNATIVE 2 : Wildcard SSL Certificate** - If you have a wildcard certificate, you will also need to provide a DNS name you wish to use for that certificate:
 
     ```powershell
     Set-Location "$env:SystemDrive\choco-setup\files"
-    .\Set-SslSecurity.ps1 -Thumbprint '<YOUR_CUSTOM_SSL_CERT_THUMBPRINT_HERE>' -CertificateDnsName '<YOUR_DESIRED_FQDN_HERE>' -Hardened
+    .\Set-SslSecurity.ps1 -Thumbprint '<YOUR_CUSTOM_SSL_CERT_THUMBPRINT_HERE>' -CertificateDnsName '<YOUR_DESIRED_FQDN_HERE>'
     ```
 
     For example, with a wildcard certificate with a thumbprint of `deee9b2fabb24bdaae71d82286e08de1` you wish to use `chocolatey.foo.org`, the following would be required:
 
     ```powershell
     Set-Location "$env:SystemDrive\choco-setup\files"
-    .\Set-SslSecurity.ps1 -Thumbprint deee9b2fabb24bdaae71d82286e08de1 -CertificateDnsName chocolatey.foo.org -Hardened
+    .\Set-SslSecurity.ps1 -Thumbprint deee9b2fabb24bdaae71d82286e08de1 -CertificateDnsName chocolatey.foo.org
     ```
 
     > <details>
@@ -215,7 +215,7 @@ Below are the minimum requirements for setting up your C4B server via this guide
     > </ul>
     > </details>
 
-    > :mag: **FYI**: A `Readme.html` file will now be generated on your desktop. This file contains login information for all 3 web portals (CCM, Nexus, and Jenkins). This `Readme.html`, along with all 3 web portals, will automatically be opened in your browser. 
+    > :mag: **FYI**: A `Readme.html` file will now be generated on your desktop. This file contains login information for all 3 web portals (CCM, Nexus, and Jenkins). This `Readme.html`, along with all 3 web portals, will automatically be opened in your browser.
 
 ### Step 6: Verification
 


### PR DESCRIPTION
## Description Of Changes
We remove the `-Hardened` option from the `Set-SSLSecurity` script. Instead, we always pick the options that were in Hardened.

## Motivation and Context
There's no reason we shouldn't be recommending that users secure their environment to the extent possible.

If they want to run a less secure environment, they can follow a different guide.

## Testing
- [x] Tested locally on Windows Server 2022
- [ ] Automated Testing

I installed  QSG locally using the unattend option and a wildcard certificate.

### Operating Systems Testing
- Windows Server 2022
- Windows Server 2019

## Change Types Made

* ~[ ] Bug fix (non-breaking change).~
* ~[ ] Feature / Enhancement (non-breaking change).~
* [x] Breaking change (fix or feature that could cause existing functionality to change).
* [x] Documentation changes.
* [x] PowerShell code changes.

## Change Checklist

* [x] Requires a change to the documentation.
* [ ] Documentation has been updated.
* ~[ ] Tests to cover my changes, have been added.~
* [ ] All new and existing tests passed?
* ~[ ] PowerShell code changes: PowerShell v3 compatibility checked?~

## Related Issue

Fixes #105 
