### PR TITLE
(#249) Add CCMInstallUser to Clixml

### DIFF
--- a/Start-C4bCcmSetup.ps1
+++ b/Start-C4bCcmSetup.ps1
@@ -153,6 +153,7 @@ process {
         DefaultUser          = "ccmadmin"
         DefaultPwToBeChanged = "123qwe"
         CCMDBUser            = $DatabaseUser
+        CCMInstallUser       = whoami
     }
 
     Write-Host "Chocolatey Central Management Setup has now completed" -ForegroundColor Green


### PR DESCRIPTION
Added the executing user for the CCM packages to the clixml for future reference.

## Description Of Changes
With this commit we've captured the executing user for the CCM packages and have stored that information in the clixml in case we need to retrieve that information for support purposes.

## Motivation and Context
At times the executing user for the initial installation of CCM is unknown to the current technical contact we are providing support. This allows us to retrieve that information and provide it to the technical contact when needed.

## Testing
Will be tested before merging.

### Operating Systems Testing
Windows Server 2022

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [X] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [X] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #249 
