### PR TITLE
(#281) Prevents Creation Of Unrequired Self-Signed Certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Below are the minimum requirements for setting up your C4B server via this guide
     > <li>Creates a "choco-install" raw repository</li>
     > <li>Sets up "ChocolateyInternal" on C4B Server as source, with API key</li>
     > <li>Adds firewall rule for repository access</li>
-    > <li>Installs MS Edge, and disables first-run experience</li>
+    > <li>Installs MS Edge, as Internet Explorer cannot access the Sonatype Nexus site</li>
     > <li>Outputs data to a JSON file to pass between scripts</li>
     > </ul>
     > </details>

--- a/Set-SslSecurity.ps1
+++ b/Set-SslSecurity.ps1
@@ -22,12 +22,12 @@ param(
     # Ignored if supplied alongside -Subject.
     [Parameter(ValueFromPipeline, ParameterSetName='Thumbprint')]
     [ArgumentCompleter({
-        Get-ChildItem Cert:\LocalMachine\My | ForEach-Object {
+        Get-ChildItem Cert:\LocalMachine\TrustedPeople | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new(
                 $_.Thumbprint,
                 $_.Thumbprint,
-                'ParameterValue',
-                $_.FriendlyName
+                "ParameterValue",
+                ($_.Subject -replace "^CN=(?<FQDN>.+),?.*$",'${FQDN}')
             )
         }
     })]

--- a/Start-C4bCcmSetup.ps1
+++ b/Start-C4bCcmSetup.ps1
@@ -17,8 +17,9 @@ param(
     [System.Management.Automation.PSCredential]
     $DatabaseCredential = (Get-Credential -Username ChocoUser -Message 'Create a credential for the ChocolateyManagement DB user (document this somewhere)'),
 
-    #Certificate to use for CCM service
+    # Certificate to use for CCM service
     [Parameter()]
+    [Alias('Thumbprint')]
     [String]
     $CertificateThumbprint
 )
@@ -116,31 +117,27 @@ process {
     $hostName = [System.Net.Dns]::GetHostName()
     $domainName = [System.Net.NetworkInformation.IPGlobalProperties]::GetIPGlobalProperties().DomainName
 
-    if(-Not $hostName.endswith($domainName)) {
+    if (-not $hostName.EndsWith($domainName)) {
         $hostName += "." + $domainName
     }
 
     Write-Host "Installing Chocolatey Central Management Service"
-    if($CertificateThumbprint){
+    $chocoArgs = @('install', 'chocolatey-management-service', "--source='ChocolateyInternal'", '-y', "--package-parameters-sensitive=`"/ConnectionString:'Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;User ID=$DatabaseUser;Password=$DatabaseUserPw;'`"", '--no-progress')
+    if ($CertificateThumbprint) {
         Write-Verbose "Validating certificate is in LocalMachine\TrustedPeople Store"
-        if($CertificateThumbprint -notin (Get-ChildItem Cert:\LocalMachine\TrustedPeople | Select-Object -Expand Thumbprint)){
+        if (-not (Get-Item Cert:\LocalMachine\TrustedPeople\$CertificateThumbprint -EA 0) -and -not (Get-Item Cert:\LocalMachine\My\$CertificateThumbprint -EA 0)) {
             Write-Warning "You specified $CertificateThumbprint for use with CCM service, but the certificate is not in the required LocalMachine\TrustedPeople store!"
             Write-Warning "Please place certificate with thumbprint: $CertificateThumbprint in the LocalMachine\TrustedPeople store and re-run this step"
-            throw "Certificate not in correct location....exiting."
-        } 
-        else {
+            throw "Certificate not in correct location... exiting."
+        } elseif ($MyCertificate = Get-Item Cert:\LocalMachine\My\$CertificateThumbprint -EA 0) {
+            Write-Verbose "Copying certificate from 'Personal' store to 'TrustedPeople'"
+            Copy-CertToStore $MyCertificate
+        } else {
             Write-Verbose "Certificate has been successfully found in correct store"
-            $chocoArgs = @('install', 'chocolatey-management-service', '-y', "--package-parameters-sensitive='/ConnectionString:Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;User Id=$DatabaseUser;Password=$DatabaseUserPw'")
-            & Invoke-Choco @chocoArgs
-
-            Set-CcmCertificate -CertificateThumbprint $CertificateThumbprint
         }
+        $chocoArgs += @("--package-parameters='/CertificateThumbprint=$CertificateThumbprint'")
     }
-
-    else {
-        $chocoArgs = @('install', 'chocolatey-management-service', "--source='ChocolateyInternal'", '-y', "--package-parameters-sensitive=`"/ConnectionString:'Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;User ID=$DatabaseUser;Password=$DatabaseUserPw;'`"", '--no-progress')
-        & Invoke-Choco @chocoArgs
-    }
+    & Invoke-Choco @chocoArgs
 
     Write-Host "Installing Chocolatey Central Management Website"
     $chocoArgs = @('install', 'chocolatey-management-web', "--source='ChocolateyInternal'", '-y', "--package-parameters-sensitive=""'/ConnectionString:Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;User ID=$DatabaseUser;Password=$DatabaseUserPw;'""", '--no-progress')

--- a/Start-C4bSetup.ps1
+++ b/Start-C4bSetup.ps1
@@ -63,6 +63,16 @@ param(
     # the local machine certificate stores.
     # Only used in Unattend mode for the SSL setup script.
     [Parameter(ParameterSetName='Unattended')]
+    [ArgumentCompleter({
+        Get-ChildItem Cert:\LocalMachine\TrustedPeople | ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new(
+                $_.Thumbprint,
+                $_.Thumbprint,
+                "ParameterValue",
+                ($_.Subject -replace "^CN=(?<FQDN>.+),?.*$",'${FQDN}')
+            )
+        }
+    })]
     [string]
     $Thumbprint,
 

--- a/Start-C4bSetup.ps1
+++ b/Start-C4bSetup.ps1
@@ -150,16 +150,14 @@ try {
 
     # Kick off unattended running of remaining setup scripts.
     if ($Unattend) {
+        $Certificate = @{}
+        if ($Thumbprint) {$Certificate.Thumbprint = $Thumbprint}
+
         Set-Location "$env:SystemDrive\choco-setup\files"
         .\Start-C4BNexusSetup.ps1
-        .\Start-C4bCcmSetup.ps1 -DatabaseCredential $DatabaseCredential
+        .\Start-C4bCcmSetup.ps1 @Certificate -DatabaseCredential $DatabaseCredential
         .\Start-C4bJenkinsSetup.ps1
-        if ($Thumbprint) {
-            .\Set-SslSecurity.ps1 -Thumbprint $Thumbprint
-        }
-        else {
-            .\Set-SslSecurity.ps1
-        }
+        .\Set-SslSecurity.ps1 @Certificate
     }
 } finally {
     $ErrorActionPreference = $DefaultEap

--- a/scripts/Set-JenkinsCert.ps1
+++ b/scripts/Set-JenkinsCert.ps1
@@ -11,7 +11,19 @@
 param(
     # Thumbprint of the certificate stored in the Trusted People cert-store.
     [Parameter(Mandatory)]
-    [string]$Thumbprint,
+    [Alias("CertificateThumbprint")]
+    [ArgumentCompleter({
+        Get-ChildItem Cert:\LocalMachine\TrustedPeople | ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new(
+                $_.Thumbprint,
+                $_.Thumbprint,
+                "ParameterValue",
+                ($_.Subject -replace "^CN=(?<FQDN>.+),?.*$",'${FQDN}')
+            )
+        }
+    })]
+    [String]
+    $Thumbprint,
 
     # Port number to use for Jenkins HTTPS.
     [uint16]$Port = 7443

--- a/scripts/Set-NexusCert.ps1
+++ b/scripts/Set-NexusCert.ps1
@@ -18,7 +18,18 @@ PS> .\Set-NexusCert.ps1 -Thumbprint 'Your_Certificate_Thumbprint_Value' -NexusPo
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)]
-    [string]
+    [Alias("CertificateThumbprint")]
+    [ArgumentCompleter({
+        Get-ChildItem Cert:\LocalMachine\TrustedPeople | ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new(
+                $_.Thumbprint,
+                $_.Thumbprint,
+                "ParameterValue",
+                ($_.Subject -replace "^CN=(?<FQDN>.+),?.*$",'${FQDN}')
+            )
+        }
+    })]
+    [String]
     $Thumbprint,
 
     [Parameter()]


### PR DESCRIPTION


## Description Of Changes
This change ensures the Chocolatey Management Service package gets the appropriate parameter in order to not generate unneeded certificate(s).

## Motivation and Context
The Chocolatey-Management-Service package generates a self-signed certificate to use if no thumbprint is specified as a parameter.

Regardless of if a certificate was specified, we were installing it without a thumbprint and then setting the certificate later.

This resulted in an unused self-signed certificate being generated and stored.

## Testing

### Operating Systems Testing
- Windows Server 2022 (Local, Automated)
- Windows Server 2019 (Automated Only)
## Change Types Made

* ~[ ] Bug fix (non-breaking change).~
* [x] Feature / Enhancement (non-breaking change).
* ~[ ] Breaking change (fix or feature that could cause existing functionality to change).~
* ~[ ] Documentation changes.~
* [x] PowerShell code changes.

## Change Checklist

* ~[ ] Requires a change to the documentation.~
* ~[ ] Documentation has been updated.~
* ~[ ] Tests to cover my changes, have been added.~
* ~[ ] All new and existing tests passed?~
* [x] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #281 
