### PR TITLE
Fixes Jenkins Pushing and ClientSetup

### DIFF
--- a/Start-C4bNexusSetup.ps1
+++ b/Start-C4bNexusSetup.ps1
@@ -84,7 +84,11 @@ process {
     # Add ChocolateyInternal as a source repository
     Invoke-Choco source add -n 'ChocolateyInternal' -s "$((Get-NexusRepository -Name 'ChocolateyInternal').url)/index.json" --priority 1
 
-    #Remove Local Chocolatey Setup Source
+    # Add ChocolateyTest as a source repository, to enable authenticated pushing
+    Invoke-Choco source add -n 'ChocolateyTest' -s "$((Get-NexusRepository -Name 'ChocolateyTest').url)/index.json"
+    Invoke-Choco source disable -n 'ChocolateyTest'
+
+    # Remove Local Chocolatey Setup Source
     $chocoArgs = @('source', 'remove', '--name="LocalChocolateySetup"')
     & Invoke-Choco @chocoArgs
     

--- a/scripts/ClientSetup.ps1
+++ b/scripts/ClientSetup.ps1
@@ -84,12 +84,12 @@ if ($Credential) {
 
 # Find the latest version of Chocolatey, if a version was not specified
 $NupkgUrl = if (-not $ChocolateyVersion) {
-    $QueryUrl = ($RepositoryUrl.TrimEnd('/index.json'), "v3/registration/Chocolatey/index.json") -join '/'
+    $QueryUrl = (($RepositoryUrl -replace '/index\.json$'), "v3/registration/Chocolatey/index.json") -join '/'
     $Result = $webClient.DownloadString($QueryUrl) | ConvertFrom-Json
     $Result.items.items[-1].packageContent
 } else {
     # Otherwise, assume the URL
-    "$($RepositoryUrl.TrimEnd('/index.json'))/v3/content/chocolatey/$($ChocolateyVersion)/chocolatey.$($ChocolateyVersion).nupkg"
+    "$($RepositoryUrl -replace '/index\.json$')/v3/content/chocolatey/$($ChocolateyVersion)/chocolatey.$($ChocolateyVersion).nupkg"
 }
 
 # Download the NUPKG


### PR DESCRIPTION
## Description Of Changes
This change ensures credentials for each potential source are added to the machine, for Jenkins to use. It also tightens up the ClientSetup script, to ensure it's not going to fail when used with repositories named by others.

## Motivation and Context
Updates to Chocolatey CLI mean that we can not rely on implicit credentials for a source.

## Testing

- Installed on a local system
- Verified Chocolatey 2.4.1 was installed
- Ran "Internalize packages from the Community Repository" with a package
- Checked that the build succeeded, and the package was present in the test repository

### Operating Systems Testing
- Windows Server 2019

## Change Types Made

* [x] Bug fix (non-breaking change).
* ~[ ] Feature / Enhancement (non-breaking change).~
* ~[ ] Breaking change (fix or feature that could cause existing functionality to change).~
* ~[ ] Documentation changes.~
* [x] PowerShell code changes.

## Change Checklist

* ~[ ] Requires a change to the documentation.~
* ~[ ] Documentation has been updated.~
* ~[ ] Tests to cover my changes, have been added.~
* [x] All new and existing tests passed?
* ~[ ] PowerShell code changes: PowerShell v3 compatibility checked?~

## Related Issue

Fixes #286 

Fixes #285 
