### PR TITLE
(fix) Enable Sources before Pushing

### DIFF
--- a/jenkins/Internalize packages from the Community Repository/config.xml
+++ b/jenkins/Internalize packages from the Community Repository/config.xml
@@ -31,19 +31,28 @@
       powershell '''
           $temp = Join-Path -Path $env:TEMP -ChildPath ([GUID]::NewGuid()).Guid
           $null = New-Item -Path $temp -ItemType Directory
+          $LocalRepoSource = $(choco source --limit-output | ConvertFrom-Csv -Delimiter '|' -Header Name, Uri, Disabled).Where{
+              $_.Uri -eq $env:P_DST_URL
+          }[0]
+
           Write-Output "Created temporary directory '$temp'."
           ($env:P_PKG_LIST).split(';,') | ForEach-Object {
               choco download $_ --no-progress --internalize --force --internalize-all-urls --append-use-original-location --output-directory=$temp --source='https://community.chocolatey.org/api/v2/'
               if ($LASTEXITCODE -eq 0) {
-				        (Get-Item -Path (Join-Path -Path $temp -ChildPath "*.nupkg")).fullname | ForEach-Object {
-      					  choco push $_ --source "$($env:P_DST_URL)" --api-key "$($env:P_API_KEY)" --force
-					        if ($LASTEXITCODE -eq 0) {
-						        Write-Verbose "Package '$_' pushed to '$($env:P_DST_URL)'.";
-					        }
-					        else {
-						        Write-Verbose "Package '$_' could not be pushed to '$($env:P_DST_URL)'.`nThis could be because it already exists in the repository at a higher version and can be mostly ignored. Check error logs."
-					        }
-				        }
+                try {
+                  if ([bool]::Parse($LocalRepoSource.Disabled)) {choco source enable --name="$($LocalRepoSource.Name)" -r | Write-Verbose}
+                  (Get-Item -Path (Join-Path -Path $temp -ChildPath "*.nupkg")).fullname | ForEach-Object {
+                    choco push $_ --source "$($env:P_DST_URL)" --api-key "$($env:P_API_KEY)" --force
+                    if ($LASTEXITCODE -eq 0) {
+                      Write-Verbose "Package '$_' pushed to '$($env:P_DST_URL)'.";
+                    }
+                    else {
+                      Write-Verbose "Package '$_' could not be pushed to '$($env:P_DST_URL)'.`nThis could be because it already exists in the repository at a higher version and can be mostly ignored. Check error logs."
+                    }
+                  }
+                } finally {
+                  if ([bool]::Parse($LocalRepoSource.Disabled)) {choco source disable --name="$($LocalRepoSource.Name)" -r | Write-Verbose}
+                }
               }
               else {
                   Write-Output "Failed to download package '$_'"


### PR DESCRIPTION
## Description Of Changes
This change ensures that sources are enabled before we attempt to push if they are disabled.

## Motivation and Context
Chocolatey sources that are disabled need to be enabled before we can rely on their stored credentials.

## Testing
Tested locally.

- Deployed branch
- Ran `internalize...` cloudflared [success]
- Ran `internalize...` firefox [success]
- Pushed an old version of dbatools to the test repository
- Ran `Update test repository...` [success]

![image](https://github.com/user-attachments/assets/821490ba-6691-4910-a942-cf98f628760f)

### Operating Systems Testing
- Windows Server 2022 (local)

## Change Types Made

* [x] Bug fix (non-breaking change).
* ~[ ] Feature / Enhancement (non-breaking change).~
* ~[ ] Breaking change (fix or feature that could cause existing functionality to change).~
* ~[ ] Documentation changes.~
* [x] PowerShell code changes.

## Change Checklist

* ~[ ] Requires a change to the documentation.~
* ~[ ] Documentation has been updated.~
* ~[ ] Tests to cover my changes, have been added.~ (these will come in a later branch)
* [x] All new and existing tests passed?
* ~[ ] PowerShell code changes: PowerShell v3 compatibility checked?~
