### PR TITLE
(#298) Add CCM Salt Value Generation Higher in Script

### DIFF
--- a/Start-C4bCcmSetup.ps1
+++ b/Start-C4bCcmSetup.ps1
@@ -195,6 +195,17 @@ process {
     }
     choco config set centralManagementServiceUrl "$($CcmEndpoint):24020/ChocolateyManagementService"
 
+    #Generate CCM Salt Values
+    if (-not (Get-ChocoEnvironmentProperty ClientSalt)) {
+        $ClientSaltValue = New-ServicePassword
+        Set-ChocoEnvironmentProperty ClientSalt $ClientSaltValue
+    }
+
+    if (-not (Get-ChocoEnvironmentProperty ServiceSalt)) {
+        $ServiceSaltValue = New-ServicePassword
+        Set-ChocoEnvironmentProperty ServiceSalt $ServiceSaltValue
+    }
+
     # Updating the Registration Script
     $EndpointScript = "$PSScriptRoot\scripts\Register-C4bEndpoint.ps1"
     Invoke-TextReplacementInFile -Path $EndpointScript -Replacement @{
@@ -234,20 +245,9 @@ process {
         Set-ChocoEnvironmentProperty CCMEncryptionPassword $CCMEncryptionPassword
     }
 
-    # Set Client and Service salts
-    if (-not (Get-ChocoEnvironmentProperty ClientSalt)) {
-        $ClientSaltValue = New-ServicePassword
-        Set-ChocoEnvironmentProperty ClientSalt $ClientSaltValue
-
-        Invoke-Choco config set centralManagementClientCommunicationSaltAdditivePassword $ClientSaltValue.ToPlainText()
-    }
-
-    if (-not (Get-ChocoEnvironmentProperty ServiceSalt)) {
-        $ServiceSaltValue = New-ServicePassword
-        Set-ChocoEnvironmentProperty ServiceSalt $ServiceSaltValue
-
-        Invoke-Choco config set centralManagementServiceCommunicationSaltAdditivePassword $ServiceSaltValue.ToPlainText()
-    }
+    # Set Client and Service salts in Chocolatey Config
+    Invoke-Choco config set centralManagementClientCommunicationSaltAdditivePassword $ClientSaltValue.ToPlainText()
+    Invoke-Choco config set centralManagementServiceCommunicationSaltAdditivePassword $ServiceSaltValue.ToPlainText()
 
     # Set Website Root Address
     Update-CcmSettings -CcmEndpoint $CCmEndpoint -Credential $CCMCredential -Settings @{


### PR DESCRIPTION
## Description Of Changes
- Create block for CCM Salt Generation
- Ensures CCM Salt values are set in README.md file

## Motivation and Context
Populate CCM salt value parameters in Register-C4bEndpoint.ps1

## Testing
1. Local QSG build on Server 2025

### Operating Systems Testing
- Server 2025 (local)
- Server 2022 (automated tests)
- Server 2019 (automated tests)

## Change Types Made
* ~[ ] Bug fix (non-breaking change).~
* ~[ ] Feature / Enhancement (non-breaking change).~
* [X] Breaking change (fix or feature that could cause existing functionality to change).
* ~[ ] Documentation changes.~
* [X] PowerShell code changes.

## Change Checklist
* ~[ ] Requires a change to the documentation.~
* ~[ ] Documentation has been updated.~
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* ~[ ] PowerShell code changes: PowerShell v3 compatibility checked?~

## Related Issue
Fixes #298 
