### PR TITLE
(#151) Add Nexus, Jenkins, and CCM Packages to upgradeAllExceptions 

### DIFF
--- a/Start-C4bCcmSetup.ps1
+++ b/Start-C4bCcmSetup.ps1
@@ -184,6 +184,11 @@ process {
     }
     & Invoke-Choco @chocoArgs
 
+    # Add CCM & .Net Dependencies to upgradeAllExceptions list
+    $upgradeAllExceptions = choco config get --name=upgradeAllExceptions --limit-output
+    $chocoArgs = @('config', 'set', '--name=upgradeAllExceptions', "--value=dotnet-aspnetcoremodule-v2,dotnet-8.0-runtime,dotnet-8.0-aspnetruntime,chocolatey-management-database,chocolatey-management-service,chocolatey-management-web,$upgradeAllExceptions")
+    & Invoke-Choco @chocoArgs
+
     # Setup Website SSL
     if ($Thumbprint) {
         Stop-CcmService

--- a/Start-C4bJenkinsSetup.ps1
+++ b/Start-C4bJenkinsSetup.ps1
@@ -64,6 +64,11 @@ process {
     $chocoArgs = @('install', 'jenkins', "--source='ChocolateyInternal'", '-y', '--no-progress')
     & Invoke-Choco @chocoArgs
 
+    # Add Jenkins & Java Dependency to upgradeAllExceptions list
+    $upgradeAllExceptions = choco config get --name=upgradeAllExceptions --limit-output
+	$chocoArgs = @('config', 'set', '--name=upgradeAllExceptions', "--value=jenkins,temurin21jre,$upgradeAllExceptions")
+    & Invoke-Choco @chocoArgs
+
     # Jenkins needs a moment
     Wait-Site Jenkins
 

--- a/Start-C4bNexusSetup.ps1
+++ b/Start-C4bNexusSetup.ps1
@@ -54,6 +54,10 @@ process {
     $chocoArgs = @('install', 'nexus-repository', '-y' ,'--no-progress', "--package-parameters='/Fqdn:localhost'")
     & Invoke-Choco @chocoArgs
 
+    # Add nexus-repository to upgradeAllExceptions list
+    $chocoArgs = @('config', 'set', '--name=upgradeAllExceptions', '--value=nexus-repository', '--limit-output')
+    & Invoke-Choco @chocoArgs
+
     $chocoArgs = @('install', 'nexushell', '-y' ,'--no-progress')
     & Invoke-Choco @chocoArgs
 

--- a/tests/packages.ps1
+++ b/tests/packages.ps1
@@ -31,3 +31,14 @@ $RepositoryOnlyPackages = @(
     @{Name = 'chocolateygui.extension' }
     @{Name = 'dotnetfx' }
 )
+$upgradeAllExceptionPackages = @(
+    @{Name = 'chocolatey-management-database' }
+    @{Name = 'chocolatey-management-service' }
+    @{Name = 'chocolatey-management-web' }
+    @{Name = 'dotnet-8.0-aspnetruntime' }
+    @{Name = 'dotnet-8.0-runtime' }
+    @{Name = 'dotnet-aspnetcoremodule-v2' }
+    @{Name = 'jenkins' }
+    @{Name = 'nexus-repository' }
+    @{Name = 'Temurin21jre' }
+)

--- a/tests/server.tests.ps1
+++ b/tests/server.tests.ps1
@@ -24,6 +24,16 @@ Describe "Server Integrity" {
         }
     }
 
+    Context "Packages Set as Upgrade All Exceptions" {
+        BeforeAll {
+            $upgradeAllExceptionsList = (choco config get --name=upgradeAllExceptions --limit-output).Split(',')
+        }
+
+        It "<Name> is part of the upgradeAllExceptions list" -ForEach $upgradeAllExceptionPackages {
+            $Name | Should -BeIn $upgradeAllExceptionsList
+        }
+    }
+
     Context "Readme File" {
         It "Readme file was created" {
             Test-Path (Join-Path "$env:PUBLIC\Desktop" -ChildPath 'Readme.html') | Should -Be $true


### PR DESCRIPTION
## Description Of Changes
Add the following packages to the upgradeAllException Config on the local server:
- jenkins
- temurin21jre
- dotnet-aspnetcoremodule-v2
- dotnet-8.0-runtime
- dotnet-8.0-aspnetruntime
- chocolatey-management-database
- chocolatey-management-service
- chocolatey-management-web
- nexus-repository

## Motivation and Context
All of these packages either have a specific upgrade order and/or specific parameters needing to be passed when upgraded. 

## Testing
1. Local Build on Server 2025

### Operating Systems Testing
- Windows Server 2025

## Change Types Made
* ~[ ] Bug fix (non-breaking change).~
* [X] Feature / Enhancement (non-breaking change).
* ~[ ] Breaking change (fix or feature that could cause existing functionality to change).~
* ~[ ] Documentation changes.~
* [X] PowerShell code changes.

## Change Checklist
* ~[ ] Requires a change to the documentation.~
* ~[ ] Documentation has been updated.~
* [X] Tests to cover my changes, have been added.
* [X] All new and existing tests passed?

## Related Issue
Fixes #151 
