### PR TITLE
(#300) Add Server 2025 & Remove Server 2019 From Tests

### DIFF
--- a/.github/workflows/Helpers.psm1
+++ b/.github/workflows/Helpers.psm1
@@ -7,7 +7,7 @@ function New-TestVM {
         [Parameter()]
         [string]$Name = "qsg-$((New-Guid).ToString() -replace '-' -replace '^(.{11}).+$', '$1')",
 
-        [ValidateSet("Win2022AzureEditionCore", "Win2019Datacenter")]
+        [ValidateSet("Win2022AzureEditionCore", "2025-datacenter-azure-edition-core")]
         [string]$Image = "Win2022AzureEditionCore",
 
         [ArgumentCompleter({

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ on:
 
       images:
         description: The Azure images to test on.
-        default: Win2022AzureEditionCore, Win2019Datacenter
+        default: Win2022AzureEditionCore, 2025-datacenter-azure-edition-core
         type: string
 
       variants:
@@ -64,7 +64,7 @@ jobs:
               $Trigger = Invoke-RestMethod "$GitHubApi/repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission" @AuthHeaders
 
               if ($Trigger.Permission -in @("admin", "write")) {
-                $Images = "Win2022AzureEditionCore", "Win2019Datacenter"
+                $Images = "Win2022AzureEditionCore", "2025-datacenter-azure-edition-core"
                 $Variants = "self-signed", "single", "wildcard"
               } else {
                 Write-Error "Action was triggered by '${{ github.actor }}', who has '$TriggerPermission': Cancelling build."


### PR DESCRIPTION
## Description Of Changes
Add Server 2025 and remove Server 2019 from builds.

## Motivation and Context
Deprecate Server 2019 and run with the 2 latest versions of Windows Server as our recommendation for QSG.

## Testing
- N/A

### Operating Systems Testing
- N/A

## Change Types Made
* ~[ ] Bug fix (non-breaking change).~
* ~[ ] Feature / Enhancement (non-breaking change).~
* [X] Breaking change (fix or feature that could cause existing functionality to change).
* [x] Documentation changes.
* [x] PowerShell code changes.

## Change Checklist
* [X] Requires a change to the documentation.
* [ ] Documentation has been updated.
* ~[ ] Tests to cover my changes, have been added.~
* [ ] All new and existing tests passed?
* ~[ ] PowerShell code changes: PowerShell v3 compatibility checked?~
* ~[ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).~

## Related Issue
Fixes #300