### PR TITLE
(#312) Fixes Issue with Certificate Incorrectly Being Identified as Self-Signed

### DIFF
--- a/Start-C4bCcmSetup.ps1
+++ b/Start-C4bCcmSetup.ps1
@@ -170,13 +170,14 @@ try {
             Copy-CertToStore $Certificate
         } else {
             Write-Verbose "Certificate has been successfully found in correct store"
+            $Certificate = Get-Item Cert:\LocalMachine\TrustedPeople\$Thumbprint
         }
         $chocoArgs += @("--package-parameters='/CertificateThumbprint=$Thumbprint'")
     }
     & Invoke-Choco @chocoArgs
 
     # If not specified, the installation will have generated a certificate
-    if (-not $Certificate) { $Certificate = Get-Item Cert:\LocalMachine\My\* }
+    if (-not $Certificate) { $Certificate = Get-Item Cert:\LocalMachine\TrustedPeople\* }
 
     Write-Host "Installing Chocolatey Central Management Website"
     $chocoArgs = @('install', 'chocolatey-management-web', "--source='ChocolateyInternal'", '-y', "--package-parameters-sensitive=""'/ConnectionString:Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;User ID=$DatabaseUser;Password=$DatabaseUserPw;'""", '--no-progress')

--- a/Start-C4bCcmSetup.ps1
+++ b/Start-C4bCcmSetup.ps1
@@ -51,7 +51,7 @@ param(
         }
     )
 )
-process {
+try {
     $DefaultEap = $ErrorActionPreference
     $ErrorActionPreference = 'Stop'
     Start-Transcript -Path "$env:SystemDrive\choco-setup\logs\Start-C4bCcmSetup-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
@@ -165,17 +165,18 @@ process {
             Write-Warning "You specified $Thumbprint for use with CCM service, but the certificate is not in the required LocalMachine\TrustedPeople store!"
             Write-Warning "Please place certificate with thumbprint: $Thumbprint in the LocalMachine\TrustedPeople store and re-run this step"
             throw "Certificate not in correct location... exiting."
-        } elseif ($MyCertificate = Get-Item Cert:\LocalMachine\My\$Thumbprint -EA 0) {
+        } elseif ($Certificate = Get-Item Cert:\LocalMachine\My\$Thumbprint -EA 0) {
             Write-Verbose "Copying certificate from 'Personal' store to 'TrustedPeople'"
-            Copy-CertToStore $MyCertificate
+            Copy-CertToStore $Certificate
         } else {
             Write-Verbose "Certificate has been successfully found in correct store"
         }
         $chocoArgs += @("--package-parameters='/CertificateThumbprint=$Thumbprint'")
     }
     & Invoke-Choco @chocoArgs
-    
-    if (-not $MyCertificate) { $MyCertificate = Get-Item Cert:\LocalMachine\My\* }
+
+    # If not specified, the installation will have generated a certificate
+    if (-not $Certificate) { $Certificate = Get-Item Cert:\LocalMachine\My\* }
 
     Write-Host "Installing Chocolatey Central Management Website"
     $chocoArgs = @('install', 'chocolatey-management-web', "--source='ChocolateyInternal'", '-y', "--package-parameters-sensitive=""'/ConnectionString:Server=Localhost\SQLEXPRESS;Database=ChocolateyManagement;User ID=$DatabaseUser;Password=$DatabaseUserPw;'""", '--no-progress')
@@ -215,12 +216,12 @@ process {
 
         # Set a default value for TrustCertificate if we're using a self-signed cert
         '(?<Parameter>\s+\$TrustCertificate)(?<Value>\s*=\s*\$true)?(?<Comma>,)?(?!\))' = "`${Parameter}$(
-        if (Test-SelfSignedCertificate -Certificate $MyCertificate) {' = $true'}
+        if (Test-SelfSignedCertificate -Certificate $Certificate) {' = $true'}
         )`${Comma}"
     }
 
     # Create the site hosting the certificate import script on port 80
-    if ($MyCertificate.NotAfter -gt (Get-Date).AddYears(5)) {
+    if ($Certificate.NotAfter -gt (Get-Date).AddYears(5)) {
         .\scripts\New-IISCertificateHost.ps1
     }
 
@@ -265,7 +266,7 @@ process {
     }
 
     Write-Host "Chocolatey Central Management Setup has now completed" -ForegroundColor Green
-
+} finally {
     $ErrorActionPreference = $DefaultEap
     Stop-Transcript
 }


### PR DESCRIPTION
## Description Of Changes

Modifies the logic when a certificate was found to be in the right place such that it stores a $Certificate variable. Also changes $MyCertificate to $Certificate, to better match other scripts.

## Motivation and Context

In the circumstance where the certificate was found in the right place, the script would not set $Certificate (formerly $MyCertificate) and consequently evaluate the (missing) certificate as self-signed.

## Testing

- Spun up environment with a non-self-signed cert that was already in TrustedPeople (formerly My)
- Check the Register script and ensure that the TrustCertificate parameter defaults to false

### Operating Systems Testing
- Windows 2022

## Change Types Made

* [x] Bug fix (non-breaking change).
* ~[ ] Feature / Enhancement (non-breaking change).~
* ~[ ] Breaking change (fix or feature that could cause existing functionality to change).~
* ~[ ] Documentation changes.~
* [x] PowerShell code changes.

## Change Checklist

* ~[ ] Requires a change to the documentation.~
* ~[ ] Documentation has been updated.~
* ~[ ] Tests to cover my changes, have been added.~
* [ ] All new and existing tests passed?
* ~[ ] PowerShell code changes: PowerShell v3 compatibility checked?~
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

Fixes #312 