### PR TITLE
(#315) Add Parameter to Allow Skipping ChocolateyGUI Installation

### DIFF
--- a/scripts/ClientSetup.ps1
+++ b/scripts/ClientSetup.ps1
@@ -74,11 +74,16 @@ param(
     [Hashtable[]]
     $AdditionalPackages,
 
-    # Allows for the addition of alternative sources after the base conifguration  has been applied.
+    # Allows for the addition of alternative sources after the base configuration  has been applied.
     # Can override base configuration with this parameter
     [Parameter()]
     [Hashtable[]]
-    $AdditionalSources
+    $AdditionalSources,
+
+    # Allows for the skipping of ChocolateyGUI installation.
+    [Parameter()]
+    [Switch]
+    $SkipChocolateyGUI
 )
 
 Set-ExecutionPolicy Bypass -Scope Process -Force
@@ -162,8 +167,10 @@ choco upgrade chocolatey.extension --confirm --source="'ChocolateyInternal'" --n
     }
 )
 
+if (-not $SkipChocolateyGUI){
 choco upgrade chocolateygui --confirm --source="'ChocolateyInternal'" --no-progress
 choco upgrade chocolateygui.extension --confirm --source="'ChocolateyInternal'" --no-progress
+}
 
 choco upgrade chocolatey-agent --confirm --source="'ChocolateyInternal'"
 

--- a/scripts/Register-C4bEndpoint.ps1
+++ b/scripts/Register-C4bEndpoint.ps1
@@ -7,7 +7,7 @@
     Some endpoints may require a different set of features. The default installation will apply our _recommended_ configuration.
     However, you can override these defaults or enable/disable additional features by providing the `-AdditionalFeatures` parameter.
 
-    In this example we will disable the use of the background service so non-admin users cannot use Chocolatey (not recommended), and enable Gloabl Confirmation so you no longer need to pass -y when performing a package operation.
+    In this example we will disable the use of the background service so non-admin users cannot use Chocolatey (not recommended), and enable Global Confirmation so you no longer need to pass -y when performing a package operation.
     
     . .\Register-C4bEndpoint.ps1 -RepositoryCredential (Get-Credential) -AdditionalFeatures @{ useBackgroundService = 'Disabled'; allowGlobalCOnfirmation = 'Enabled' }
     
@@ -93,7 +93,7 @@ Param(
     [Hashtable]
     $AdditionalConfiguration,
 
-    # Allows for the toggling of additonal features that is applied after the base configuration.
+    # Allows for the toggling of additional features that is applied after the base configuration.
     # Can override base configuration with this parameter
     [Parameter()]
     [Hashtable]
@@ -104,11 +104,16 @@ Param(
     [Hashtable[]]
     $AdditionalPackages,
 
-    # Allows for the addition of alternative sources after the base conifguration  has been applied.
+    # Allows for the addition of alternative sources after the base configuration  has been applied.
     # Can override base configuration with this parameter
     [Parameter()]
     [Hashtable[]]
     $AdditionalSources,
+
+    # Allows for the skipping of ChocolateyGUI installation.
+    [Parameter()]
+    [Switch]
+    $SkipChocolateyGUI,
 
     # If passed, downloads the certificate from the client server before initializing Chocolatey Agent
     [Parameter()]


### PR DESCRIPTION
## Description Of Changes
Added `-SkipChocolateyGUI` parameter to allow for endpoint registration with/without Chocolatey GUI installation.

## Motivation and Context
Requested in Chocolatey Discord by C4B User in #315 

## Testing
1. Local QSG VM

### Operating Systems Testing
- Windows Server 2025

## Change Types Made
* [ ] Bug fix (non-breaking change).
* [X] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [X] PowerShell code changes.

## Change Checklist

* [X] Requires a change to the documentation. ([Docs PR](https://github.com/chocolatey/docs/pull/1322))
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue
Fixes #315 