### PR TITLE
(#319) Add Key Export Policy to Self Signed Cert Generation

### DIFF
--- a/Initialize-C4bSetup.ps1
+++ b/Initialize-C4bSetup.ps1
@@ -193,6 +193,7 @@ try {
                 KeyUsage          = "KeyEncipherment", "DigitalSignature"
                 DnsName           = $CertificateDnsName
                 NotAfter          = (Get-Date).AddYears(10)
+                KeyExportPolicy   = "Exportable"
             }
 
             $Certificate = New-SelfSignedCertificate @CertificateArgs


### PR DESCRIPTION
## Description Of Changes
Add Key Export Policy of Exportable to `New-SelfSignedCertificate` Cmdlet call in Initialize-C4bSetup.ps1

## Motivation and Context
Seems more reliable at generating the type of certificate the guide needs.

## Testing
1. Local VM Trsting

### Operating Systems Testing
- Windows Server 2025

## Change Types Made
* [ ] Bug fix (non-breaking change).
* [X] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist
* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [X] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue
Fixes #319
